### PR TITLE
Refactor API wrappers

### DIFF
--- a/openalex_python/api/__init__.py
+++ b/openalex_python/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .authors_api import AuthorsApi
 from .autocomplete_api import AutocompleteApi
+from .base import BaseApi
 from .concepts_api import ConceptsApi
 from .funders_api import FundersApi
 from .general_api import GeneralApi
@@ -18,6 +19,7 @@ from .works_api import WorksApi
 __all__ = [
     "AuthorsApi",
     "AutocompleteApi",
+    "BaseApi",
     "ConceptsApi",
     "FundersApi",
     "GeneralApi",

--- a/openalex_python/api/authors_api.py
+++ b/openalex_python/api/authors_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class AuthorsApi:
+class AuthorsApi(BaseApi):
     """Access authors-related API endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def authors_get(self, **params: Any) -> Any:
         """Return a list of authors."""
-        return self.api_client.call_api(
-            "/authors", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/authors", **params)
 
     def authors_id_get(self, id: str, **params: Any) -> Any:
         """Return a single author."""
-        return self.api_client.call_api(
-            f"/authors/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/authors/{id}", **params)
 
     def authors_random_get(self, **params: Any) -> Any:
         """Return a random author."""
-        return self.api_client.call_api(
-            "/authors/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/authors/random", **params)
 
     def people_get(self, **params: Any) -> Any:
         """Alias for :meth:`authors_get`."""

--- a/openalex_python/api/autocomplete_api.py
+++ b/openalex_python/api/autocomplete_api.py
@@ -2,26 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class AutocompleteApi:
+class AutocompleteApi(BaseApi):
     """Autocomplete API."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
-
-    def _get(self, path: str, **params: Any) -> Any:
-        return self.api_client.call_api(
-            path, "GET", query_params=_prep(params), _return_http_data_only=True
-        )
 
     def autocomplete_authors_get(self, q: str, **params: Any) -> Any:
         """Autocomplete authors."""

--- a/openalex_python/api/base.py
+++ b/openalex_python/api/base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from openalex_python.api_client import ApiClient
+
+
+class BaseApi:
+    """Base class for API wrappers."""
+
+    def __init__(self, api_client: ApiClient | None = None) -> None:
+        self.api_client = api_client or ApiClient()
+
+    @staticmethod
+    def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
+        """Filter out ``None`` values from parameters."""
+        return [(k, v) for k, v in params.items() if v is not None]
+
+    def _get(self, path: str, **params: Any) -> Any:
+        """Perform a GET request and return deserialized data."""
+        return self.api_client.call_api(
+            path,
+            "GET",
+            query_params=self._prep(params),
+            _return_http_data_only=True,
+        )
+
+    def _post(self, path: str, body: Any, **params: Any) -> Any:
+        """Perform a POST request and return deserialized data."""
+        return self.api_client.call_api(
+            path,
+            "POST",
+            body=body,
+            query_params=self._prep(params),
+            _return_http_data_only=True,
+        )

--- a/openalex_python/api/concepts_api.py
+++ b/openalex_python/api/concepts_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class ConceptsApi:
+class ConceptsApi(BaseApi):
     """Access concept endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def concepts_get(self, **params: Any) -> Any:
         """Return a list of concepts."""
-        return self.api_client.call_api(
-            "/concepts", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/concepts", **params)
 
     def concepts_id_get(self, id: str, **params: Any) -> Any:
         """Return a single concept."""
-        return self.api_client.call_api(
-            f"/concepts/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/concepts/{id}", **params)
 
     def concepts_random_get(self, **params: Any) -> Any:
         """Return a random concept."""
-        return self.api_client.call_api(
-            "/concepts/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/concepts/random", **params)
 
 
 __all__ = ["ConceptsApi"]

--- a/openalex_python/api/funders_api.py
+++ b/openalex_python/api/funders_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class FundersApi:
+class FundersApi(BaseApi):
     """Access funder endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def funders_get(self, **params: Any) -> Any:
         """Return a list of funders."""
-        return self.api_client.call_api(
-            "/funders", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/funders", **params)
 
     def funders_id_get(self, id: str, **params: Any) -> Any:
         """Return a single funder."""
-        return self.api_client.call_api(
-            f"/funders/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/funders/{id}", **params)
 
     def funders_random_get(self, **params: Any) -> Any:
         """Return a random funder."""
-        return self.api_client.call_api(
-            "/funders/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/funders/random", **params)
 
 
 __all__ = ["FundersApi"]

--- a/openalex_python/api/general_api.py
+++ b/openalex_python/api/general_api.py
@@ -2,27 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class GeneralApi:
+class GeneralApi(BaseApi):
     """Access root endpoint."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def root_get(self, **params: Any) -> Any:
         """Return the API root description."""
-        return self.api_client.call_api(
-            "/", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/", **params)
 
 
 __all__ = ["GeneralApi"]

--- a/openalex_python/api/institutions_api.py
+++ b/openalex_python/api/institutions_api.py
@@ -2,48 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class InstitutionsApi:
+class InstitutionsApi(BaseApi):
     """Access institution endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def institutions_get(self, **params: Any) -> Any:
         """Return a list of institutions."""
-        return self.api_client.call_api(
-            "/institutions",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/institutions", **params)
 
     def institutions_id_get(self, id: str, **params: Any) -> Any:
         """Return a single institution."""
-        return self.api_client.call_api(
-            f"/institutions/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/institutions/{id}", **params)
 
     def institutions_random_get(self, **params: Any) -> Any:
         """Return a random institution."""
-        return self.api_client.call_api(
-            "/institutions/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/institutions/random", **params)
 
 
 __all__ = ["InstitutionsApi"]

--- a/openalex_python/api/keywords_api.py
+++ b/openalex_python/api/keywords_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class KeywordsApi:
+class KeywordsApi(BaseApi):
     """Access keyword endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def keywords_get(self, **params: Any) -> Any:
         """Return a list of keywords."""
-        return self.api_client.call_api(
-            "/keywords", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/keywords", **params)
 
     def keywords_id_get(self, id: str, **params: Any) -> Any:
         """Return a single keyword."""
-        return self.api_client.call_api(
-            f"/keywords/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/keywords/{id}", **params)
 
     def keywords_random_get(self, **params: Any) -> Any:
         """Return a random keyword."""
-        return self.api_client.call_api(
-            "/keywords/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/keywords/random", **params)
 
 
 __all__ = ["KeywordsApi"]

--- a/openalex_python/api/publishers_api.py
+++ b/openalex_python/api/publishers_api.py
@@ -2,48 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class PublishersApi:
+class PublishersApi(BaseApi):
     """Access publisher endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def publishers_get(self, **params: Any) -> Any:
         """Return a list of publishers."""
-        return self.api_client.call_api(
-            "/publishers",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/publishers", **params)
 
     def publishers_id_get(self, id: str, **params: Any) -> Any:
         """Return a single publisher."""
-        return self.api_client.call_api(
-            f"/publishers/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/publishers/{id}", **params)
 
     def publishers_random_get(self, **params: Any) -> Any:
         """Return a random publisher."""
-        return self.api_client.call_api(
-            "/publishers/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/publishers/random", **params)
 
 
 __all__ = ["PublishersApi"]

--- a/openalex_python/api/sources_api.py
+++ b/openalex_python/api/sources_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class SourcesApi:
+class SourcesApi(BaseApi):
     """Access source endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def sources_get(self, **params: Any) -> Any:
         """Return a list of sources."""
-        return self.api_client.call_api(
-            "/sources", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/sources", **params)
 
     def sources_id_get(self, id: str, **params: Any) -> Any:
         """Return a single source."""
-        return self.api_client.call_api(
-            f"/sources/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/sources/{id}", **params)
 
     def sources_random_get(self, **params: Any) -> Any:
         """Return a random source."""
-        return self.api_client.call_api(
-            "/sources/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/sources/random", **params)
 
 
 __all__ = ["SourcesApi"]

--- a/openalex_python/api/text_api.py
+++ b/openalex_python/api/text_api.py
@@ -2,35 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class TextApi:
+class TextApi(BaseApi):
     """Access text analysis endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
-
-    def _get(self, path: str, **params: Any) -> Any:
-        return self.api_client.call_api(
-            path, "GET", query_params=_prep(params), _return_http_data_only=True
-        )
-
-    def _post(self, path: str, body: Any, **params: Any) -> Any:
-        return self.api_client.call_api(
-            path,
-            "POST",
-            body=body,
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
 
     def text_concepts_get(self, title: str, **params: Any) -> Any:
         """Extract concepts from text title."""

--- a/openalex_python/api/topics_api.py
+++ b/openalex_python/api/topics_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class TopicsApi:
+class TopicsApi(BaseApi):
     """Access topic endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def topics_get(self, **params: Any) -> Any:
         """Return a list of topics."""
-        return self.api_client.call_api(
-            "/topics", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/topics", **params)
 
     def topics_id_get(self, id: str, **params: Any) -> Any:
         """Return a single topic."""
-        return self.api_client.call_api(
-            f"/topics/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/topics/{id}", **params)
 
     def topics_random_get(self, **params: Any) -> Any:
         """Return a random topic."""
-        return self.api_client.call_api(
-            "/topics/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/topics/random", **params)
 
 
 __all__ = ["TopicsApi"]

--- a/openalex_python/api/works_api.py
+++ b/openalex_python/api/works_api.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
-from openalex_python.api_client import ApiClient
+from .base import BaseApi
 
 
-def _prep(params: Mapping[str, Any]) -> list[tuple[str, Any]]:
-    return [(k, v) for k, v in params.items() if v is not None]
-
-
-class WorksApi:
+class WorksApi(BaseApi):
     """Access work endpoints."""
-
-    def __init__(self, api_client: ApiClient | None = None) -> None:
-        self.api_client = api_client or ApiClient()
 
     def works_get(self, **params: Any) -> Any:
         """Return a list of works."""
-        return self.api_client.call_api(
-            "/works", "GET", query_params=_prep(params), _return_http_data_only=True
-        )
+        return self._get("/works", **params)
 
     def works_id_get(self, id: str, **params: Any) -> Any:
         """Return a single work."""
-        return self.api_client.call_api(
-            f"/works/{id}",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get(f"/works/{id}", **params)
 
     def works_random_get(self, **params: Any) -> Any:
         """Return a random work."""
-        return self.api_client.call_api(
-            "/works/random",
-            "GET",
-            query_params=_prep(params),
-            _return_http_data_only=True,
-        )
+        return self._get("/works/random", **params)
 
 
 __all__ = ["WorksApi"]


### PR DESCRIPTION
## Summary
- centralize API helper logic in `BaseApi`
- have every API wrapper inherit from `BaseApi`
- export `BaseApi` in the api package

## Testing
- `ruff check --fix .` *(fails: many existing lint errors)*
- `mypy .` *(fails: many missing type hints in tests)*
- `pytest -q` *(fails: coverage < 80%)*

------
https://chatgpt.com/codex/tasks/task_e_6844fcd15098832b9ba2b21a69cd00ec