### PR TITLE
Use ConfigDict and modern serializers

### DIFF
--- a/openalex/config.py
+++ b/openalex/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 
 class OpenAlexConfig(BaseModel):
@@ -102,7 +102,4 @@ class OpenAlexConfig(BaseModel):
             params["mailto"] = self.email
         return params
 
-    class Config:
-        """Pydantic config."""
-
-        frozen = True
+    model_config = ConfigDict(frozen=True)

--- a/openalex/models/author.py
+++ b/openalex/models/author.py
@@ -123,6 +123,6 @@ class Author(OpenAlexEntity):
         return [c.display_name for c in self.x_concepts if c.display_name]
 
 
-from .work import DehydratedConcept, DehydratedInstitution  # noqa: E402,TCH001
+from .work import DehydratedConcept, DehydratedInstitution  # noqa: E402,TC001
 
 Author.model_rebuild()

--- a/openalex/models/base.py
+++ b/openalex/models/base.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer
 
 
 class EntityType(str, Enum):
@@ -31,12 +31,13 @@ class OpenAlexBase(BaseModel):
         use_enum_values=True,
         validate_assignment=True,
         str_strip_whitespace=True,
-        json_encoders={
-            datetime: lambda v: v.isoformat(),
-            date: lambda v: v.isoformat(),
-            HttpUrl: str,
-        },
     )
+
+    @field_serializer("*", when_used="json")
+    def _serialize(self, v: Any) -> str | Any:
+        if isinstance(v, datetime | date | HttpUrl):
+            return str(v)
+        return v
 
 
 class OpenAlexEntity(OpenAlexBase):

--- a/openalex/models/institution.py
+++ b/openalex/models/institution.py
@@ -162,6 +162,6 @@ class Institution(OpenAlexEntity):
         )
 
 
-from .work import DehydratedConcept  # noqa: E402,TCH001
+from .work import DehydratedConcept  # noqa: E402,TC001
 
 Institution.model_rebuild()

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -141,6 +141,6 @@ class Source(OpenAlexEntity):
         return issns
 
 
-from .work import DehydratedConcept  # noqa: E402,TCH001
+from .work import DehydratedConcept  # noqa: E402,TC001
 
 Source.model_rebuild()


### PR DESCRIPTION
## Summary
- switch pydantic BaseModel configs to `ConfigDict`
- replace deprecated `json_encoders` with `field_serializer`
- update noqa codes per ruff

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q -o asyncio_default_fixture_loop_scope=function --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68458d4aa554832bbcbe3c0a30d3041f