### PR TITLE
Fix pytest_asyncio deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"
+asyncio_default_fixture_loop_scope = "function"
 addopts = [
     "-ra",
     "--strict-markers",


### PR DESCRIPTION
## Summary
- set `asyncio_default_fixture_loop_scope` in pytest config to avoid deprecation warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458f5cb094832b92a08353d71a7bac