### PR TITLE
Improve test coverage to exceed 90%

### DIFF
--- a/tests/test_additional_models.py
+++ b/tests/test_additional_models.py
@@ -1,0 +1,95 @@
+from openalex.models import (
+    Funder,
+    Institution,
+    Publisher,
+    Source,
+    SourceType,
+    Topic,
+    Keyword,
+)
+from openalex.models import work as work_models
+
+
+def test_funder_metrics_and_government() -> None:
+    funder = Funder(
+        id="F1",
+        display_name="National Science Department",
+        grants_count=10,
+        works_count=5,
+    )
+    assert funder.funding_per_work == 2
+    assert funder.is_government_funder()
+
+
+def test_funder_no_works() -> None:
+    funder = Funder(id="F2", display_name="Private Org", works_count=0, grants_count=1)
+    assert funder.funding_per_work is None
+    assert not funder.is_government_funder()
+
+
+def test_institution_extras() -> None:
+    inst = Institution(id="I1", display_name="Solo", lineage=["I1"], repositories=[])
+    assert inst.parent_institution is None
+    assert inst.root_institution is None
+    assert inst.repository_count() == 0
+    assert not inst.has_location()
+
+    inst2 = Institution(
+        id="I2",
+        display_name="Located",
+        geo={"latitude": 1.0, "longitude": 2.0},
+        repositories=[{"id": "R1", "display_name": "Repo1"}],
+    )
+    assert inst2.repository_count() == 1
+    assert inst2.has_location()
+
+
+def test_publisher_properties() -> None:
+    pub = Publisher(id="P1", display_name="Pub", hierarchy_level=0, country_codes=["US"], parent_publisher=None)
+    assert pub.is_parent_publisher is True
+    assert pub.countries == ["US"]
+    assert pub.has_parent() is False
+
+
+def test_source_repository_and_issns() -> None:
+    source = Source(
+        id="S1",
+        display_name="Repo",
+        type=SourceType.REPOSITORY,
+        issn_l="1234-5678",
+        issn=["1111-2222"],
+    )
+    assert source.is_repository
+    assert source.all_issns() == ["1234-5678", "1111-2222"]
+
+
+def test_topic_levels_and_keywords() -> None:
+    topic = Topic(
+        id="T1",
+        display_name="AI",
+        domain={"id": "D", "display_name": "Domain"},
+        keywords=["Machine", "Learning"],
+    )
+    assert topic.level == 0
+    assert topic.has_keyword("machine")
+    assert not topic.has_keyword("other")
+
+    topic2 = Topic(id="T2", display_name="Sub", field={"id": "F", "display_name": "Field"})
+    assert topic2.level == 1
+
+    topic3 = Topic(id="T3", display_name="Deep", subfield={"id": "S", "display_name": "Sub"})
+    assert topic3.level == 2
+
+
+def test_keyword_not_popular() -> None:
+    kw = Keyword(id="K1", display_name="test")
+    assert kw.average_citations_per_work is None
+    assert not kw.is_popular(threshold=1)
+
+
+def test_work_module_filters() -> None:
+    filt = work_models.WorksFilter().with_publication_year(2020).with_type("article")
+    params = filt.with_open_access().to_params()
+    assert "publication_year:2020" in params["filter"]
+    assert "type:article" in params["filter"]
+    assert "is_oa:true" in params["filter"]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,6 +3,9 @@ import pytest
 
 from openalex.exceptions import (
     APIError,
+    NetworkError,
+    TimeoutError,
+    ValidationError,
     AuthenticationError,
     NotFoundError,
     RateLimitError,
@@ -26,3 +29,24 @@ def test_raise_for_status(status: int, exc: type[Exception]) -> None:
     with pytest.raises(exc):
         raise_for_status(response)
 
+
+
+def test_validation_and_network_errors() -> None:
+    err = ValidationError("bad", field="field", value=123)
+    assert err.field == "field"
+    assert err.value == 123
+
+    net = NetworkError(original_error=ValueError("x"))
+    assert isinstance(net.original_error, ValueError)
+
+    timeout = TimeoutError()
+    assert isinstance(timeout, NetworkError)
+
+
+def test_raise_for_status_non_json() -> None:
+    request = httpx.Request("GET", "https://api.openalex.org/test")
+    response = httpx.Response(502, text="<!doctype html>", request=request)
+    with pytest.raises(APIError) as exc_info:
+        raise_for_status(response)
+    assert exc_info.value.status_code == 502
+    assert "Server error" in str(exc_info.value)

--- a/tests/test_filters_extra.py
+++ b/tests/test_filters_extra.py
@@ -1,0 +1,45 @@
+from datetime import date
+import pytest
+
+from openalex.models import BaseFilter, WorksFilter, GroupBy
+from pydantic import ValidationError
+
+
+def test_base_filter_validation() -> None:
+    assert BaseFilter().filter is None
+    with pytest.raises(ValidationError):
+        BaseFilter(filter=123)
+
+    assert BaseFilter(select=None).select is None
+    with pytest.raises(ValidationError):
+        BaseFilter(select=123)
+
+
+def test_build_filter_string() -> None:
+    bf = BaseFilter()
+    filters = {
+        "bool": True,
+        "list": [1, 2],
+        "date": date(2020, 1, 1),
+        "str": "x",
+        "none": None,
+    }
+    result = bf._build_filter_string(filters)
+    assert "bool:true" in result
+    assert "list:1|2" in result
+    assert "date:2020-01-01" in result
+    assert "str:x" in result
+    assert "none" not in result
+
+
+def test_to_params_and_works_filter() -> None:
+    wf = WorksFilter().with_publication_year(2020).with_type(["article", "book"]).with_open_access(False)
+    wf = wf.model_copy(update={"group_by": GroupBy.TYPE, "per_page": 10, "select": ["id", "title"]})
+    params = wf.to_params()
+    assert params["group-by"] == GroupBy.TYPE
+    assert params["per-page"] == 10
+    assert params["select"] == "id,title"
+    filt = params["filter"]
+    assert "publication_year:2020" in filt
+    assert "type:article|book" in filt
+    assert "is_oa:false" in filt


### PR DESCRIPTION
## Summary
- add new model tests covering institutions, funders, publishers, topics and sources
- expand exception tests for additional branches
- add extra filter validation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c290f6ac832bb338081aea1c9e50