### PR TITLE
Enable resources coverage with dedicated tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ source = ["openalex"]
 omit = [
     "*/tests/*",
     "*/__init__.py",
-    "openalex/resources/*",
 ]
 
 [tool.coverage.report]

--- a/tests/resources/test_authors.py
+++ b/tests/resources/test_authors.py
@@ -1,0 +1,14 @@
+import pytest
+from openalex.models import Author
+from openalex.resources import AsyncAuthorsResource
+
+
+@pytest.mark.asyncio
+async def test_async_by_orcid(async_client, httpx_mock, mock_author_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/authors/https://orcid.org/0000-0003-4237-824X?mailto=test%40example.com",
+        json=mock_author_response,
+    )
+    author = await async_client.authors.by_orcid("0000-0003-4237-824X")
+    assert isinstance(author, Author)
+    assert author.id == mock_author_response["id"]

--- a/tests/resources/test_base.py
+++ b/tests/resources/test_base.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic import BaseModel
+from openalex.resources.base import BaseResource
+from openalex.models import BaseFilter
+from openalex.exceptions import ValidationError as OpenAlexValidationError
+
+
+class DummyModel(BaseModel):
+    id: int
+
+
+class DummyResource(BaseResource[DummyModel, BaseFilter]):
+    endpoint = "dummy"
+    model_class = DummyModel
+    filter_class = BaseFilter
+
+
+def test_parse_list_error(client, httpx_mock):
+    dummy = DummyResource(client)
+    httpx_mock.add_response(url="https://api.openalex.org/dummy?mailto=test%40example.com", json={"results": [{}]})
+    with pytest.raises(OpenAlexValidationError):
+        dummy.list()

--- a/tests/resources/test_concepts.py
+++ b/tests/resources/test_concepts.py
@@ -1,0 +1,28 @@
+import pytest
+from openalex.models import Concept
+
+
+def test_by_wikidata_formats(client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/concepts/https://www.wikidata.org/entity/Q123?mailto=test%40example.com",
+        json={"id": "https://openalex.org/C123"},
+    )
+    concept = client.concepts.by_wikidata("Q123")
+    assert isinstance(concept, Concept)
+
+    httpx_mock.add_response(
+        url="https://api.openalex.org/concepts/https://www.wikidata.org/entity/Q456?mailto=test%40example.com",
+        json={"id": "https://openalex.org/C456"},
+    )
+    concept = client.concepts.by_wikidata("456")
+    assert concept.id == "https://openalex.org/C456"
+
+
+@pytest.mark.asyncio
+async def test_async_by_wikidata(async_client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/concepts/https://www.wikidata.org/entity/Q789?mailto=test%40example.com",
+        json={"id": "https://openalex.org/C789"},
+    )
+    concept = await async_client.concepts.by_wikidata("789")
+    assert concept.id == "https://openalex.org/C789"

--- a/tests/resources/test_funders.py
+++ b/tests/resources/test_funders.py
@@ -1,0 +1,21 @@
+import pytest
+from openalex.models import Funder
+
+
+def test_by_ror(client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/funders/https://ror.org/12345?mailto=test%40example.com",
+        json={"id": "https://openalex.org/F123"},
+    )
+    funder = client.funders.by_ror("12345")
+    assert funder.id == "https://openalex.org/F123"
+
+
+@pytest.mark.asyncio
+async def test_async_by_ror(async_client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/funders/https://ror.org/67890?mailto=test%40example.com",
+        json={"id": "https://openalex.org/F678"},
+    )
+    funder = await async_client.funders.by_ror("67890")
+    assert isinstance(funder, Funder)

--- a/tests/resources/test_institutions.py
+++ b/tests/resources/test_institutions.py
@@ -1,0 +1,21 @@
+import pytest
+from openalex.models import Institution
+
+
+def test_by_ror(client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/institutions/https://ror.org/03vek6s52?mailto=test%40example.com",
+        json={"id": "https://openalex.org/I123"},
+    )
+    institution = client.institutions.by_ror("03vek6s52")
+    assert isinstance(institution, Institution)
+
+
+@pytest.mark.asyncio
+async def test_async_by_ror(async_client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/institutions/https://ror.org/03abc9876?mailto=test%40example.com",
+        json={"id": "https://openalex.org/I456"},
+    )
+    institution = await async_client.institutions.by_ror("03abc9876")
+    assert institution.id == "https://openalex.org/I456"

--- a/tests/resources/test_keywords.py
+++ b/tests/resources/test_keywords.py
@@ -1,0 +1,10 @@
+from openalex.models import Keyword
+
+
+def test_list_keywords(client, httpx_mock, mock_list_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/keywords?mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    result = client.keywords.list()
+    assert isinstance(result.results[0].id, str)

--- a/tests/resources/test_publishers.py
+++ b/tests/resources/test_publishers.py
@@ -1,0 +1,10 @@
+from openalex.models import Publisher
+
+
+def test_list_publishers(client, httpx_mock, mock_list_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/publishers?mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    result = client.publishers.list()
+    assert result.meta.count == 100

--- a/tests/resources/test_sources.py
+++ b/tests/resources/test_sources.py
@@ -1,0 +1,21 @@
+import pytest
+from openalex.models import Source
+
+
+def test_by_issn(client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/sources/issn:12345678?mailto=test%40example.com",
+        json={"id": "https://openalex.org/S123"},
+    )
+    source = client.sources.by_issn("1234-5678")
+    assert source.id == "https://openalex.org/S123"
+
+
+@pytest.mark.asyncio
+async def test_async_by_issn(async_client, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/sources/issn:87654321?mailto=test%40example.com",
+        json={"id": "https://openalex.org/S876"},
+    )
+    source = await async_client.sources.by_issn("8765-4321")
+    assert isinstance(source, Source)

--- a/tests/resources/test_topics.py
+++ b/tests/resources/test_topics.py
@@ -1,0 +1,10 @@
+from openalex.models import Topic
+
+
+def test_list_topics(client, httpx_mock, mock_list_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/topics?mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    result = client.topics.list()
+    assert len(result.results) == 1

--- a/tests/resources/test_works.py
+++ b/tests/resources/test_works.py
@@ -1,0 +1,39 @@
+import pytest
+from openalex.models import Work
+from openalex.models.filters import WorksFilter
+from openalex.resources import WorksResource
+
+
+def test_clone_with_raw_filter(client):
+    res = WorksResource(client, default_filter=WorksFilter(filter="type:article"))
+    clone = res.cited_by("https://openalex.org/W1")
+    assert clone._default_filter.filter["raw"] == "type:article"
+    assert clone._default_filter.filter["cites"] == "W1"
+
+
+def test_cited_by_full_url(client, httpx_mock, mock_list_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/works?filter=authorships.institutions.id%3AI123&mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    resource = client.works.by_institution("https://openalex.org/I123")
+    result = resource.list()
+    assert result.meta.count == 100
+
+
+@pytest.mark.asyncio
+async def test_async_methods(async_client, httpx_mock, mock_list_response):
+    httpx_mock.add_response(
+        url="https://api.openalex.org/works?filter=authorships.author.id%3AA1&mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    resource = await async_client.works.by_author("https://openalex.org/A1")
+    await resource.list()
+    httpx_mock.add_response(
+        url="https://api.openalex.org/works?per-page=200&page=1&mailto=test%40example.com",
+        json=mock_list_response,
+    )
+    paginator = async_client.works.paginate(max_results=1)
+    async for item in paginator:
+        assert isinstance(item, Work)
+        break


### PR DESCRIPTION
## Summary
- include `openalex/resources` in coverage
- add dedicated test modules per resource to cover missing paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ca2b59b0832ba73b0b7418cdde09