### PR TITLE
Fix code smells in tests

### DIFF
--- a/tests/models/test_additional_models.py
+++ b/tests/models/test_additional_models.py
@@ -1,11 +1,11 @@
 from openalex.models import (
     Funder,
     Institution,
+    Keyword,
     Publisher,
     Source,
     SourceType,
     Topic,
-    Keyword,
 )
 from openalex.models import work as work_models
 

--- a/tests/models/test_author.py
+++ b/tests/models/test_author.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from openalex.models import Author
-import pytest
 
 
 class TestAuthor:

--- a/tests/models/test_author_helpers.py
+++ b/tests/models/test_author_helpers.py
@@ -1,4 +1,3 @@
-import pytest
 
 from openalex.models import (
     Author,

--- a/tests/models/test_filters_extra.py
+++ b/tests/models/test_filters_extra.py
@@ -1,8 +1,9 @@
 from datetime import date
-import pytest
 
-from openalex.models import BaseFilter, WorksFilter, GroupBy
+import pytest
 from pydantic import ValidationError
+
+from openalex.models import BaseFilter, GroupBy, WorksFilter
 
 
 def test_base_filter_validation() -> None:

--- a/tests/resources/test_authors.py
+++ b/tests/resources/test_authors.py
@@ -1,6 +1,6 @@
 import pytest
+
 from openalex.models import Author
-from openalex.resources import AsyncAuthorsResource
 
 
 @pytest.mark.asyncio

--- a/tests/resources/test_base.py
+++ b/tests/resources/test_base.py
@@ -1,8 +1,9 @@
 import pytest
 from pydantic import BaseModel
-from openalex.resources.base import BaseResource
-from openalex.models import BaseFilter
+
 from openalex.exceptions import ValidationError as OpenAlexValidationError
+from openalex.models import BaseFilter
+from openalex.resources.base import BaseResource
 
 
 class DummyModel(BaseModel):

--- a/tests/resources/test_concepts.py
+++ b/tests/resources/test_concepts.py
@@ -1,4 +1,5 @@
 import pytest
+
 from openalex.models import Concept
 
 

--- a/tests/resources/test_funders.py
+++ b/tests/resources/test_funders.py
@@ -1,4 +1,5 @@
 import pytest
+
 from openalex.models import Funder
 
 

--- a/tests/resources/test_institutions.py
+++ b/tests/resources/test_institutions.py
@@ -1,4 +1,5 @@
 import pytest
+
 from openalex.models import Institution
 
 

--- a/tests/resources/test_keywords.py
+++ b/tests/resources/test_keywords.py
@@ -1,4 +1,3 @@
-from openalex.models import Keyword
 
 
 def test_list_keywords(client, httpx_mock, mock_list_response):

--- a/tests/resources/test_publishers.py
+++ b/tests/resources/test_publishers.py
@@ -1,4 +1,3 @@
-from openalex.models import Publisher
 
 
 def test_list_publishers(client, httpx_mock, mock_list_response):

--- a/tests/resources/test_sources.py
+++ b/tests/resources/test_sources.py
@@ -1,4 +1,5 @@
 import pytest
+
 from openalex.models import Source
 
 

--- a/tests/resources/test_topics.py
+++ b/tests/resources/test_topics.py
@@ -1,4 +1,3 @@
-from openalex.models import Topic
 
 
 def test_list_topics(client, httpx_mock, mock_list_response):

--- a/tests/resources/test_works.py
+++ b/tests/resources/test_works.py
@@ -1,4 +1,5 @@
 import pytest
+
 from openalex.models import Work
 from openalex.models.filters import WorksFilter
 from openalex.resources import WorksResource

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,12 +3,12 @@ import pytest
 
 from openalex.exceptions import (
     APIError,
-    NetworkError,
-    TimeoutError,
-    ValidationError,
     AuthenticationError,
+    NetworkError,
     NotFoundError,
     RateLimitError,
+    TimeoutError,
+    ValidationError,
     raise_for_status,
 )
 

--- a/tests/utils/test_pagination.py
+++ b/tests/utils/test_pagination.py
@@ -112,7 +112,9 @@ async def test_async_paginator_error() -> None:
         raise APIError(msg, status_code=500)
 
     paginator = AsyncPaginator(fetch)
-    with pytest.raises(APIError):
+    # Ruff's PT012 rule expects a simple statement inside ``pytest.raises``.
+    # However, we need to iterate to trigger the exception.
+    with pytest.raises(APIError):  # noqa: PT012
         async for _ in paginator:
             pass
 

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+
 import pytest
 
 from openalex.utils import (

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+
 import pytest
 
 from openalex.exceptions import APIError, NetworkError, RateLimitError


### PR DESCRIPTION
## Summary
- run Ruff on the tests and tidy imports
- clarify a pytest.raises block to make Ruff happy

## Testing
- `pytest -q`
- `ruff check openalex`


------
https://chatgpt.com/codex/tasks/task_e_6845dcf6cfac832b88cbec306649bf80