### PR TITLE
Apply formatting across repo

### DIFF
--- a/openalex/client.py
+++ b/openalex/client.py
@@ -218,7 +218,6 @@ class OpenAlex:
             results=results,
         )
 
-
     def text_aboutness(
         self,
         title: str,

--- a/tests/models/test_additional_models.py
+++ b/tests/models/test_additional_models.py
@@ -22,13 +22,17 @@ def test_funder_metrics_and_government() -> None:
 
 
 def test_funder_no_works() -> None:
-    funder = Funder(id="F2", display_name="Private Org", works_count=0, grants_count=1)
+    funder = Funder(
+        id="F2", display_name="Private Org", works_count=0, grants_count=1
+    )
     assert funder.funding_per_work is None
     assert not funder.is_government_funder()
 
 
 def test_institution_extras() -> None:
-    inst = Institution(id="I1", display_name="Solo", lineage=["I1"], repositories=[])
+    inst = Institution(
+        id="I1", display_name="Solo", lineage=["I1"], repositories=[]
+    )
     assert inst.parent_institution is None
     assert inst.root_institution is None
     assert inst.repository_count() == 0
@@ -45,7 +49,13 @@ def test_institution_extras() -> None:
 
 
 def test_publisher_properties() -> None:
-    pub = Publisher(id="P1", display_name="Pub", hierarchy_level=0, country_codes=["US"], parent_publisher=None)
+    pub = Publisher(
+        id="P1",
+        display_name="Pub",
+        hierarchy_level=0,
+        country_codes=["US"],
+        parent_publisher=None,
+    )
     assert pub.is_parent_publisher is True
     assert pub.countries == ["US"]
     assert pub.has_parent() is False
@@ -74,10 +84,16 @@ def test_topic_levels_and_keywords() -> None:
     assert topic.has_keyword("machine")
     assert not topic.has_keyword("other")
 
-    topic2 = Topic(id="T2", display_name="Sub", field={"id": "F", "display_name": "Field"})
+    topic2 = Topic(
+        id="T2", display_name="Sub", field={"id": "F", "display_name": "Field"}
+    )
     assert topic2.level == 1
 
-    topic3 = Topic(id="T3", display_name="Deep", subfield={"id": "S", "display_name": "Sub"})
+    topic3 = Topic(
+        id="T3",
+        display_name="Deep",
+        subfield={"id": "S", "display_name": "Sub"},
+    )
     assert topic3.level == 2
 
 
@@ -88,7 +104,11 @@ def test_keyword_not_popular() -> None:
 
 
 def test_work_module_filters() -> None:
-    filt = work_models.WorksFilter().with_publication_year(2020).with_type("article")
+    filt = (
+        work_models.WorksFilter()
+        .with_publication_year(2020)
+        .with_type("article")
+    )
     params = filt.with_open_access().to_params()
     assert "publication_year:2020" in params["filter"]
     assert "type:article" in params["filter"]

--- a/tests/models/test_author.py
+++ b/tests/models/test_author.py
@@ -8,7 +8,9 @@ from openalex.models import Author
 class TestAuthor:
     """Test Author model."""
 
-    def test_author_creation(self, mock_author_response: dict[str, Any]) -> None:
+    def test_author_creation(
+        self, mock_author_response: dict[str, Any]
+    ) -> None:
         author = Author(**mock_author_response)
 
         assert author.id == "https://openalex.org/A123456"
@@ -17,14 +19,18 @@ class TestAuthor:
         assert author.works_count == 500
         assert author.cited_by_count == 100000
 
-    def test_author_summary_stats(self, mock_author_response: dict[str, Any]) -> None:
+    def test_author_summary_stats(
+        self, mock_author_response: dict[str, Any]
+    ) -> None:
         author = Author(**mock_author_response)
 
         assert author.h_index == 120
         assert author.i10_index == 450
         assert author.summary_stats.two_year_mean_citedness == 5.2
 
-    def test_author_affiliations(self, mock_author_response: dict[str, Any]) -> None:
+    def test_author_affiliations(
+        self, mock_author_response: dict[str, Any]
+    ) -> None:
         author = Author(**mock_author_response)
 
         assert len(author.affiliations) == 1
@@ -32,7 +38,9 @@ class TestAuthor:
         assert affiliation.institution.display_name == "Tulane University"
         assert affiliation.years == [2020, 2021, 2022, 2023]
 
-    def test_author_helper_methods(self, mock_author_response: dict[str, Any]) -> None:
+    def test_author_helper_methods(
+        self, mock_author_response: dict[str, Any]
+    ) -> None:
         author = Author(**mock_author_response)
 
         assert author.works_in_year(2023) == 10

--- a/tests/models/test_author_helpers.py
+++ b/tests/models/test_author_helpers.py
@@ -1,4 +1,3 @@
-
 from openalex.models import (
     Author,
     AuthorAffiliation,
@@ -20,11 +19,15 @@ def _make_author() -> Author:
         ],
         affiliations=[
             AuthorAffiliation(
-                institution=DehydratedInstitution(id="I1", display_name="Inst A"),
+                institution=DehydratedInstitution(
+                    id="I1", display_name="Inst A"
+                ),
                 years=[2020, 2021],
             ),
             AuthorAffiliation(
-                institution=DehydratedInstitution(id="I1", display_name="Inst A"),
+                institution=DehydratedInstitution(
+                    id="I1", display_name="Inst A"
+                ),
                 years=[2021],
             ),
         ],

--- a/tests/models/test_filters_extra.py
+++ b/tests/models/test_filters_extra.py
@@ -34,8 +34,19 @@ def test_build_filter_string() -> None:
 
 
 def test_to_params_and_works_filter() -> None:
-    wf = WorksFilter().with_publication_year(2020).with_type(["article", "book"]).with_open_access(False)
-    wf = wf.model_copy(update={"group_by": GroupBy.TYPE, "per_page": 10, "select": ["id", "title"]})
+    wf = (
+        WorksFilter()
+        .with_publication_year(2020)
+        .with_type(["article", "book"])
+        .with_open_access(False)
+    )
+    wf = wf.model_copy(
+        update={
+            "group_by": GroupBy.TYPE,
+            "per_page": 10,
+            "select": ["id", "title"],
+        }
+    )
     params = wf.to_params()
     assert params["group-by"] == GroupBy.TYPE
     assert params["per-page"] == 10

--- a/tests/models/test_keyword.py
+++ b/tests/models/test_keyword.py
@@ -2,7 +2,8 @@ from openalex.models import Keyword
 
 
 def test_keyword_metrics() -> None:
-    kw = Keyword(id="K1", display_name="AI", works_count=100, cited_by_count=250)
+    kw = Keyword(
+        id="K1", display_name="AI", works_count=100, cited_by_count=250
+    )
     assert kw.average_citations_per_work == 2.5
     assert kw.is_popular(threshold=50)
-

--- a/tests/models/test_list_result.py
+++ b/tests/models/test_list_result.py
@@ -8,7 +8,9 @@ from openalex.models import ListResult, Meta, Work
 class TestListResult:
     """Test ListResult model."""
 
-    def test_list_result_creation(self, mock_list_response: dict[str, Any]) -> None:
+    def test_list_result_creation(
+        self, mock_list_response: dict[str, Any]
+    ) -> None:
         result = ListResult[Work](
             meta=Meta(**mock_list_response["meta"]),
             results=[Work(**r) for r in mock_list_response["results"]],

--- a/tests/resources/test_base.py
+++ b/tests/resources/test_base.py
@@ -18,6 +18,9 @@ class DummyResource(BaseResource[DummyModel, BaseFilter]):
 
 def test_parse_list_error(client, httpx_mock):
     dummy = DummyResource(client)
-    httpx_mock.add_response(url="https://api.openalex.org/dummy?mailto=test%40example.com", json={"results": [{}]})
+    httpx_mock.add_response(
+        url="https://api.openalex.org/dummy?mailto=test%40example.com",
+        json={"results": [{}]},
+    )
     with pytest.raises(OpenAlexValidationError):
         dummy.list()

--- a/tests/resources/test_keywords.py
+++ b/tests/resources/test_keywords.py
@@ -1,5 +1,3 @@
-
-
 def test_list_keywords(client, httpx_mock, mock_list_response):
     httpx_mock.add_response(
         url="https://api.openalex.org/keywords?mailto=test%40example.com",

--- a/tests/resources/test_publishers.py
+++ b/tests/resources/test_publishers.py
@@ -1,5 +1,3 @@
-
-
 def test_list_publishers(client, httpx_mock, mock_list_response):
     httpx_mock.add_response(
         url="https://api.openalex.org/publishers?mailto=test%40example.com",

--- a/tests/resources/test_topics.py
+++ b/tests/resources/test_topics.py
@@ -1,5 +1,3 @@
-
-
 def test_list_topics(client, httpx_mock, mock_list_response):
     httpx_mock.add_response(
         url="https://api.openalex.org/topics?mailto=test%40example.com",

--- a/tests/resources/test_works.py
+++ b/tests/resources/test_works.py
@@ -6,7 +6,9 @@ from openalex.resources import WorksResource
 
 
 def test_clone_with_raw_filter(client):
-    res = WorksResource(client, default_filter=WorksFilter(filter="type:article"))
+    res = WorksResource(
+        client, default_filter=WorksFilter(filter="type:article")
+    )
     clone = res.cited_by("https://openalex.org/W1")
     assert clone._default_filter.filter["raw"] == "type:article"
     assert clone._default_filter.filter["cites"] == "W1"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -263,7 +263,9 @@ async def test_async_client_api_key_override(config: OpenAlexConfig) -> None:
         await client.close()
 
 
-def test_request_retry(monkeypatch: pytest.MonkeyPatch, client: OpenAlex) -> None:
+def test_request_retry(
+    monkeypatch: pytest.MonkeyPatch, client: OpenAlex
+) -> None:
     calls: dict[str, Any] = {"wait_sync": [], "attempts": 0}
 
     def fake_acquire() -> float:
@@ -284,7 +286,9 @@ def test_request_retry(monkeypatch: pytest.MonkeyPatch, client: OpenAlex) -> Non
 
     monkeypatch.setattr(client.rate_limiter, "acquire", fake_acquire)
     monkeypatch.setattr(client.retry_handler, "wait_sync", fake_wait_sync)
-    monkeypatch.setattr(client.retry_handler, "get_wait_time", fake_get_wait_time)
+    monkeypatch.setattr(
+        client.retry_handler, "get_wait_time", fake_get_wait_time
+    )
     monkeypatch.setattr(client._client, "request", fake_request)
 
     resp = client._request("GET", "https://api.openalex.org/test")
@@ -293,9 +297,18 @@ def test_request_retry(monkeypatch: pytest.MonkeyPatch, client: OpenAlex) -> Non
     assert calls["wait_sync"]
 
 
-def test_search_all_error(monkeypatch: pytest.MonkeyPatch, client: OpenAlex) -> None:
+def test_search_all_error(
+    monkeypatch: pytest.MonkeyPatch, client: OpenAlex
+) -> None:
     result = ListResult(
-        meta=Meta(count=1, db_response_time_ms=1, page=1, per_page=25, groups_count=0, next_cursor=None),
+        meta=Meta(
+            count=1,
+            db_response_time_ms=1,
+            page=1,
+            per_page=25,
+            groups_count=0,
+            next_cursor=None,
+        ),
         results=[],
     )
 
@@ -316,7 +329,9 @@ def test_search_all_error(monkeypatch: pytest.MonkeyPatch, client: OpenAlex) -> 
 
 
 @pytest.mark.asyncio
-async def test_async_request_retry(monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig) -> None:
+async def test_async_request_retry(
+    monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
+) -> None:
     client = AsyncOpenAlex(config=config)
     calls = {"attempts": 0}
 
@@ -346,7 +361,9 @@ async def test_async_request_retry(monkeypatch: pytest.MonkeyPatch, config: Open
 
 @pytest.mark.asyncio
 async def test_async_autocomplete_entity(
-    httpx_mock: HTTPXMock, config: OpenAlexConfig, mock_autocomplete_response: dict[str, Any]
+    httpx_mock: HTTPXMock,
+    config: OpenAlexConfig,
+    mock_autocomplete_response: dict[str, Any],
 ) -> None:
     httpx_mock.add_response(
         url="https://api.openalex.org/autocomplete/works?q=ml&mailto=test%40example.com",
@@ -358,10 +375,19 @@ async def test_async_autocomplete_entity(
 
 
 @pytest.mark.asyncio
-async def test_async_search_all_error(monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig) -> None:
+async def test_async_search_all_error(
+    monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
+) -> None:
     client = AsyncOpenAlex(config=config)
     async_result = ListResult(
-        meta=Meta(count=1, db_response_time_ms=1, page=1, per_page=25, groups_count=0, next_cursor=None),
+        meta=Meta(
+            count=1,
+            db_response_time_ms=1,
+            page=1,
+            per_page=25,
+            groups_count=0,
+            next_cursor=None,
+        ),
         results=[],
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,9 @@ from openalex import OpenAlexConfig
 
 
 def test_headers_and_params() -> None:
-    config = OpenAlexConfig(email="test@example.com", api_key="abc", user_agent="ua")
+    config = OpenAlexConfig(
+        email="test@example.com", api_key="abc", user_agent="ua"
+    )
     headers = config.headers
     assert "test@example.com" in headers["User-Agent"]
     assert headers["Authorization"] == "Bearer abc"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,6 @@ def test_raise_for_status(status: int, exc: type[Exception]) -> None:
         raise_for_status(response)
 
 
-
 def test_validation_and_network_errors() -> None:
     err = ValidationError("bad", field="field", value=123)
     assert err.field == "field"

--- a/tests/utils/test_pagination.py
+++ b/tests/utils/test_pagination.py
@@ -9,7 +9,9 @@ from openalex.models import ListResult, Meta, Work
 from openalex.utils import AsyncPaginator, Paginator
 
 
-def _make_page(start: int, per_page: int, total: int, cursor: str | None = None) -> ListResult[Work]:
+def _make_page(
+    start: int, per_page: int, total: int, cursor: str | None = None
+) -> ListResult[Work]:
     meta = Meta(
         count=total,
         db_response_time_ms=1,
@@ -17,7 +19,10 @@ def _make_page(start: int, per_page: int, total: int, cursor: str | None = None)
         per_page=per_page,
         next_cursor=cursor,
     )
-    results = [Work(id=f"W{i}", display_name=f"Work {i}") for i in range(start, start + per_page)]
+    results = [
+        Work(id=f"W{i}", display_name=f"Work {i}")
+        for i in range(start, start + per_page)
+    ]
     return ListResult(meta=meta, results=results)
 
 
@@ -29,7 +34,9 @@ def test_paginator_iteration() -> None:
         page = int(params.get("cursor", params.get("page", 1)))
         start = (page - 1) * per_page
         next_cursor = str(page + 1) if start + per_page < total else None
-        return _make_page(start, min(per_page, total - start), total, next_cursor)
+        return _make_page(
+            start, min(per_page, total - start), total, next_cursor
+        )
 
     paginator = Paginator(fetch, per_page=2)
     items = list(paginator)
@@ -114,7 +121,7 @@ async def test_async_paginator_error() -> None:
     paginator = AsyncPaginator(fetch)
     # Ruff's PT012 rule expects a simple statement inside ``pytest.raises``.
     # However, we need to iterate to trigger the exception.
-    with pytest.raises(APIError):  # noqa: PT012
+    with pytest.raises(APIError):
         async for _ in paginator:
             pass
 

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -49,7 +49,9 @@ def test_rate_limited_decorator(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_rate_limited_decorator(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_rate_limited_decorator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[float] = []
 
     async def fake_sleep(seconds: float) -> None:
@@ -75,7 +77,9 @@ def test_rate_limiter_try_acquire_success() -> None:
 
 
 def test_sliding_window_rate_limiter() -> None:
-    limiter = SlidingWindowRateLimiter(max_requests=2, window_seconds=0.1, buffer=0)
+    limiter = SlidingWindowRateLimiter(
+        max_requests=2, window_seconds=0.1, buffer=0
+    )
     assert limiter.try_acquire()
     assert limiter.try_acquire()
     assert not limiter.try_acquire()
@@ -84,7 +88,9 @@ def test_sliding_window_rate_limiter() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_rate_limiter_context(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_rate_limiter_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[float] = []
 
     async def fake_sleep(seconds: float) -> None:

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -44,7 +44,9 @@ async def test_async_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-    wrapped = async_with_retry(func, RetryConfig(max_attempts=3, initial_wait=0))
+    wrapped = async_with_retry(
+        func, RetryConfig(max_attempts=3, initial_wait=0)
+    )
     assert await wrapped() == "done"
     assert len(attempts) == 3
 
@@ -66,7 +68,9 @@ def test_retry_config_wait_strategy() -> None:
 
 
 @pytest.mark.asyncio
-async def test_retry_handler_should_retry_and_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_retry_handler_should_retry_and_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     handler = RetryHandler(RetryConfig(max_attempts=2))
     assert handler.should_retry(APIError("server", status_code=500), 1)
     assert not handler.should_retry(APIError("server", status_code=500), 2)


### PR DESCRIPTION
## Summary
- format code with `ruff format`
- clean up async paginator tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845de8adbb4832bb377785d524b84b5