### PR TITLE
Fix topic hierarchy tests

### DIFF
--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -113,6 +113,7 @@ from .models import (
     SustainableDevelopmentGoal,
     # Topic models
     Topic,
+    TopicHierarchy,
     TopicIds,
     TopicLevel,
     Work,
@@ -224,6 +225,7 @@ __all__ = [
     "TimeoutError",
     # Topic models
     "Topic",
+    "TopicHierarchy",
     "TopicIds",
     "TopicLevel",
     "ValidationError",

--- a/openalex/models/__init__.py
+++ b/openalex/models/__init__.py
@@ -36,7 +36,7 @@ from .institution import (
 from .keyword import Keyword
 from .publisher import Publisher, PublisherIds
 from .source import APCPrice, Society, Source, SourceIds, SourceType
-from .topic import Topic, TopicIds, TopicLevel
+from .topic import Topic, TopicHierarchy, TopicIds, TopicLevel
 from .work import (
     APC,
     Authorship,
@@ -127,6 +127,7 @@ __all__ = [
     "SustainableDevelopmentGoal",
     # Topic models
     "Topic",
+    "TopicHierarchy",
     "TopicIds",
     "TopicLevel",
     # Work models


### PR DESCRIPTION
## Summary
- define `TopicLevel` enum and new `TopicHierarchy` model
- add missing fields to `Topic` and update `level` property
- export new symbols via `openalex` and `models`

## Testing
- `pytest tests/resources/test_topics.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_6845eca61724832b89b9cd066408de80