### PR TITLE
Fix filter defaults for authors tests

### DIFF
--- a/openalex/models/filters.py
+++ b/openalex/models/filters.py
@@ -40,9 +40,17 @@ class BaseFilter(BaseModel):
     )
     sort: str | None = Field(None, description="Sort field")
     group_by: str | GroupBy | None = Field(None, description="Group by field")
-    page: int | None = Field(1, ge=1, le=10000, description="Page number")
+    page: int | None = Field(
+        default=None,
+        ge=1,
+        le=10000,
+        description="Page number",
+    )
     per_page: int | None = Field(
-        25, ge=1, le=200, description="Results per page"
+        default=None,
+        ge=1,
+        le=200,
+        description="Results per page",
     )
     cursor: str | None = Field(None, description="Pagination cursor")
     sample: int | None = Field(None, ge=1, description="Random sample size")


### PR DESCRIPTION
## Summary
- stop sending page/per_page automatically
- update BaseFilter defaults to only include pagination when provided

## Testing
- `pytest tests/resources/test_authors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684653e6c5f4832bb80035a20e150a80