### PR TITLE
Fix mypy stub issue

### DIFF
--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -260,7 +260,7 @@ __all__ = [
 # defaults at import time when tests are running so such optional responses are
 # allowed.
 try:
-    from pytest_httpx import _options as _httpx_options
+    from pytest_httpx import _options as _httpx_options  # type: ignore
 
     if not getattr(_httpx_options, "_openalex_patched", False):
         _httpx_options._HTTPXMockOptions.__init__.__kwdefaults__[  # noqa: SLF001


### PR DESCRIPTION
## Summary
- ignore missing pytest_httpx stubs so mypy succeeds

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467021ecf0832b933772bece1e6ee5