### PR TITLE
Improve error handling across library

### DIFF
--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -260,12 +260,12 @@ __all__ = [
 # defaults at import time when tests are running so such optional responses are
 # allowed.
 try:
-    from pytest_httpx import _options as _httpx_options
+    from pytest_httpx import _options as _httpx_options  # type: ignore[import-not-found]
 
     if not getattr(_httpx_options, "_openalex_patched", False):
         _httpx_options._HTTPXMockOptions.__init__.__kwdefaults__[  # noqa: SLF001
             "assert_all_responses_were_requested"
         ] = False
         cast("Any", _httpx_options)._openalex_patched = True  # noqa: SLF001
-except Exception:
-    logger.debug("Failed to patch httpx mock options", exc_info=True)
+except Exception as exc:
+    logger.debug("Failed to patch httpx mock options", exc_info=exc)

--- a/openalex/client.py
+++ b/openalex/client.py
@@ -97,6 +97,21 @@ class OpenAlex:
         self.funders = FundersResource(self)
         self.keywords = KeywordsResource(self)
 
+    @staticmethod
+    def _empty_list_result() -> ListResult[Any]:
+        """Return an empty ``ListResult`` object."""
+        return ListResult(
+            meta=Meta(
+                count=0,
+                db_response_time_ms=0,
+                page=1,
+                per_page=0,
+                groups_count=0,
+                next_cursor=None,
+            ),
+            results=[],
+        )
+
     def __enter__(self) -> OpenAlex:
         """Context manager entry."""
         return self
@@ -283,23 +298,13 @@ class OpenAlex:
         for entity_type, resource in entity_types:
             try:
                 results[entity_type] = resource.search(query, **params)
-            except Exception as e:
+            except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(
                     "Failed to search %s",
                     entity_type,
-                    error=str(e),
+                    exc_info=exc,
                 )
-                results[entity_type] = ListResult(
-                    meta=Meta(
-                        count=0,
-                        db_response_time_ms=0,
-                        page=1,
-                        per_page=0,
-                        groups_count=0,
-                        next_cursor=None,
-                    ),
-                    results=[],
-                )
+                results[entity_type] = self._empty_list_result()
 
         return results
 
@@ -358,6 +363,21 @@ class AsyncOpenAlex:
         self.publishers = AsyncPublishersResource(self)
         self.funders = AsyncFundersResource(self)
         self.keywords = AsyncKeywordsResource(self)
+
+    @staticmethod
+    def _empty_list_result() -> ListResult[Any]:
+        """Return an empty ``ListResult`` object."""
+        return ListResult(
+            meta=Meta(
+                count=0,
+                db_response_time_ms=0,
+                page=1,
+                per_page=0,
+                groups_count=0,
+                next_cursor=None,
+            ),
+            results=[],
+        )
 
     async def __aenter__(self) -> AsyncOpenAlex:
         """Async context manager entry."""
@@ -535,23 +555,13 @@ class AsyncOpenAlex:
         for entity_type, task in tasks.items():
             try:
                 results[entity_type] = await task
-            except Exception as e:
+            except Exception as exc:  # pragma: no cover - defensive
                 logger.warning(
                     "Failed to search %s",
                     entity_type,
-                    error=str(e),
+                    exc_info=exc,
                 )
-                results[entity_type] = ListResult(
-                    meta=Meta(
-                        count=0,
-                        db_response_time_ms=0,
-                        page=1,
-                        per_page=0,
-                        groups_count=0,
-                        next_cursor=None,
-                    ),
-                    results=[],
-                )
+                results[entity_type] = self._empty_list_result()
 
         return results
 

--- a/openalex/exceptions.py
+++ b/openalex/exceptions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -123,7 +124,7 @@ def raise_for_status(response: httpx.Response) -> None:
     try:
         error_data = response.json()
         message = error_data.get("message", response.reason_phrase)
-    except Exception:
+    except (ValueError, json.JSONDecodeError):
         message = response.reason_phrase or f"HTTP {response.status_code}"
 
     if response.status_code == 401:

--- a/openalex/models/funder.py
+++ b/openalex/models/funder.py
@@ -87,7 +87,7 @@ class Funder(OpenAlexEntity):
                         new_time += f".{rest[0]}"
                     fixed = f"{date_part}T{new_time}"
                     return datetime.fromisoformat(fixed)
-                except Exception as exc:  # pragma: no cover - defensive
+                except ValueError as exc:  # pragma: no cover - defensive
                     msg = "Invalid datetime format"
                     raise ValueError(msg) from exc
         return v

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -89,12 +89,13 @@ class Topic(OpenAlexEntity):
         """Parse potentially malformed datetime strings."""
         if v is None or isinstance(v, datetime):
             return v
+
         try:
             return datetime.fromisoformat(v)
         except ValueError:
             try:
                 return cast("datetime", parser.parse(v))
-            except Exception:
+            except (ValueError, TypeError):
                 match = re.match(
                     r"(?P<prefix>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}):(?P<sec>\d{2})(?P<rest>.*)",
                     v,
@@ -105,8 +106,9 @@ class Topic(OpenAlexEntity):
                     new_v = f"{match.group('prefix')}:{sec:02d}{match.group('rest')}"
                     try:
                         return datetime.fromisoformat(new_v)
-                    except Exception:
+                    except ValueError:
                         return cast("datetime", parser.parse(new_v))
+
         return None
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary
- tighten exception handling and parse logic in `Topic`
- improve Funder date parsing
- centralize creation of empty search results and enhance logging in client
- refine HTTP error parsing
- ignore missing pytest_httpx stubs in `__init__`

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684674465428832b910da84e81dd588a