### PR TITLE
Refactor utils and add explicit module exports

### DIFF
--- a/openalex/client.py
+++ b/openalex/client.py
@@ -6,6 +6,13 @@ import asyncio
 from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, cast
 
+__all__ = [
+    "AsyncOpenAlex",
+    "OpenAlex",
+    "async_client",
+    "client",
+]
+
 import httpx
 from structlog import get_logger
 
@@ -558,11 +565,15 @@ class AsyncOpenAlex:
         }
 
         results: dict[str, ListResult[Any]] = {}
-        tasks_list = await asyncio.gather(*tasks.values(), return_exceptions=True)
+        tasks_list = await asyncio.gather(
+            *tasks.values(), return_exceptions=True
+        )
         for (entity_type, _), task_result in zip(
             tasks.items(), tasks_list, strict=False
         ):
-            if isinstance(task_result, Exception):  # pragma: no cover - defensive
+            if isinstance(
+                task_result, Exception
+            ):  # pragma: no cover - defensive
                 logger.warning(
                     "Failed to search %s",
                     entity_type,
@@ -570,7 +581,7 @@ class AsyncOpenAlex:
                 )
                 results[entity_type] = self._empty_list_result()
             else:
-                results[entity_type] = cast(ListResult[Any], task_result)
+                results[entity_type] = cast("ListResult[Any]", task_result)
 
         return results
 

--- a/openalex/config.py
+++ b/openalex/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+__all__ = ["OpenAlexConfig"]
+
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 

--- a/openalex/exceptions.py
+++ b/openalex/exceptions.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+__all__ = [
+    "APIError",
+    "AuthenticationError",
+    "NetworkError",
+    "NotFoundError",
+    "OpenAlexError",
+    "RateLimitError",
+    "TimeoutError",
+    "ValidationError",
+    "raise_for_status",
+]
+
 if TYPE_CHECKING:
     import httpx
 

--- a/openalex/models/author.py
+++ b/openalex/models/author.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+__all__ = ["Author", "AuthorAffiliation", "AuthorIds"]
+
 from pydantic import Field, HttpUrl
 
 from .base import CountsByYear, OpenAlexBase, OpenAlexEntity, SummaryStats

--- a/openalex/models/concept.py
+++ b/openalex/models/concept.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from pydantic import Field, HttpUrl
 
+__all__ = [
+    "Concept",
+    "ConceptAncestor",
+    "ConceptIds",
+    "RelatedConcept",
+]
+
 from .base import CountsByYear, OpenAlexBase, OpenAlexEntity, SummaryStats
 
 

--- a/openalex/models/funder.py
+++ b/openalex/models/funder.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+__all__ = ["Funder", "FunderIds"]
+
 from pydantic import Field, HttpUrl, field_validator
 
 from .base import CountsByYear, OpenAlexBase, OpenAlexEntity, Role, SummaryStats

--- a/openalex/models/institution.py
+++ b/openalex/models/institution.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+__all__ = [
+    "AssociatedInstitution",
+    "Institution",
+    "InstitutionIds",
+    "InstitutionTopic",
+    "InstitutionTopicShare",
+    "InstitutionType",
+    "Repository",
+]
+
 from pydantic import Field, HttpUrl, TypeAdapter, field_validator
 
 from .base import (

--- a/openalex/models/keyword.py
+++ b/openalex/models/keyword.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import Field
 
+__all__ = ["Keyword"]
+
 from .base import CountsByYear, OpenAlexEntity
 
 

--- a/openalex/models/publisher.py
+++ b/openalex/models/publisher.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import Field, HttpUrl
 
+__all__ = ["Publisher", "PublisherIds"]
+
 from .base import CountsByYear, OpenAlexBase, OpenAlexEntity, Role, SummaryStats
 
 

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 
+__all__ = [
+    "APCPrice",
+    "Society",
+    "Source",
+    "SourceIds",
+    "SourceType",
+]
+
 from pydantic import Field, HttpUrl, field_validator
 
 from .base import CountsByYear, OpenAlexBase, OpenAlexEntity, SummaryStats

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from enum import IntEnum
 from typing import cast
 
+__all__ = ["Topic", "TopicHierarchy", "TopicIds", "TopicLevel"]
+
 from dateutil import parser  # type: ignore
 from pydantic import (
     Field,

--- a/openalex/utils/pagination.py
+++ b/openalex/utils/pagination.py
@@ -24,6 +24,14 @@ logger = get_logger(__name__)
 T = TypeVar("T")
 
 
+def _pad_results(results: list[T], per_page: int | None) -> list[T]:
+    """Pad ``results`` to ``per_page`` length if necessary."""
+    if per_page and results and len(results) < per_page:
+        missing = per_page - len(results)
+        return results + [results[-1]] * missing
+    return results
+
+
 class Paginator(Generic[T]):
     """Synchronous paginator for OpenAlex API results."""
 
@@ -80,14 +88,7 @@ class Paginator(Generic[T]):
                 raise
 
             # Yield results
-            items = result.results
-            if (
-                result.meta.per_page
-                and result.results
-                and len(result.results) < result.meta.per_page
-            ):
-                missing = result.meta.per_page - len(result.results)
-                items = result.results + [result.results[-1]] * missing
+            items = _pad_results(result.results, result.meta.per_page)
 
             for item in items:
                 if self.max_results and self._total_fetched >= self.max_results:
@@ -223,14 +224,7 @@ class AsyncPaginator(Generic[T]):
                 raise
 
             # Yield results
-            items = result.results
-            if (
-                result.meta.per_page
-                and result.results
-                and len(result.results) < result.meta.per_page
-            ):
-                missing = result.meta.per_page - len(result.results)
-                items = result.results + [result.results[-1]] * missing
+            items = _pad_results(result.results, result.meta.per_page)
 
             for item in items:
                 if self.max_results and self._total_fetched >= self.max_results:

--- a/openalex/utils/retry.py
+++ b/openalex/utils/retry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import random
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from structlog import get_logger
@@ -51,32 +52,15 @@ def is_retryable_error(error: BaseException) -> bool:
     return False
 
 
+@dataclass(slots=True)
 class RetryConfig:
     """Configuration for retry behavior."""
 
-    def __init__(
-        self,
-        max_attempts: int = 3,
-        initial_wait: float = 1.0,
-        max_wait: float = 60.0,
-        exponential_base: float = 2.0,
-        *,
-        jitter: bool = True,
-    ) -> None:
-        """Initialize retry configuration.
-
-        Args:
-            max_attempts: Maximum number of attempts
-            initial_wait: Initial wait time in seconds
-            max_wait: Maximum wait time in seconds
-            exponential_base: Base for exponential backoff
-            jitter: Whether to add jitter to wait times
-        """
-        self.max_attempts = max_attempts
-        self.initial_wait = initial_wait
-        self.max_wait = max_wait
-        self.exponential_base = exponential_base
-        self.jitter = jitter
+    max_attempts: int = 3
+    initial_wait: float = 1.0
+    max_wait: float = 60.0
+    exponential_base: float = 2.0
+    jitter: bool = True
 
     def get_wait_strategy(self) -> Any:
         """Get tenacity wait strategy."""


### PR DESCRIPTION
## Summary
- add `__all__` declarations for several modules
- refactor pagination helpers with a shared `_pad_results` routine
- switch `RetryConfig` to a dataclass with slots
- expose client classes through module exports
- run formatting and style fixes

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684688a4ba4c832b8a52109eccc5beb7