### PR TITLE
Refactor constants and cleanup utilities

### DIFF
--- a/openalex/config.py
+++ b/openalex/config.py
@@ -26,12 +26,6 @@ class OpenAlexConfig(BaseModel):
         default=None,
         description="Premium API key for higher rate limits",
     )
-    retry_count: int = Field(
-        default=3,
-        ge=0,
-        le=10,
-        description="Number of retries for failed requests",
-    )
     timeout: float = Field(
         default=30.0,
         gt=0,
@@ -43,12 +37,6 @@ class OpenAlexConfig(BaseModel):
         ge=1,
         le=200,
         description="Default items per page",
-    )
-    max_retries: int = Field(
-        default=3,
-        ge=0,
-        le=10,
-        description="Maximum number of retries",
     )
     user_agent: str | None = Field(
         default=None,

--- a/openalex/constants.py
+++ b/openalex/constants.py
@@ -1,0 +1,18 @@
+"""Common string and numeric constants for OpenAlex."""
+
+OPENALEX_ID_PREFIX = "https://openalex.org/"
+ORCID_URL_PREFIX = "https://orcid.org/"
+DOI_URL_PREFIX = "https://doi.org/"
+PMID_PREFIX = "pmid:"
+MAG_PREFIX = "mag:"
+
+MAX_SECONDS_IN_MINUTE = 59
+
+__all__ = [
+    "DOI_URL_PREFIX",
+    "MAG_PREFIX",
+    "MAX_SECONDS_IN_MINUTE",
+    "OPENALEX_ID_PREFIX",
+    "ORCID_URL_PREFIX",
+    "PMID_PREFIX",
+]

--- a/openalex/models/concept.py
+++ b/openalex/models/concept.py
@@ -101,17 +101,25 @@ class Concept(OpenAlexEntity):
 
     def works_in_year(self, year: int) -> int:
         """Return number of works published in a specific year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.works_count
-        return 0
+        return next(
+            (
+                year_data.works_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def citations_in_year(self, year: int) -> int:
         """Return citation count for a specific year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.cited_by_count
-        return 0
+        return next(
+            (
+                year_data.cited_by_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def active_years(self) -> list[int]:
         """Return list of years with publication activity."""

--- a/openalex/models/funder.py
+++ b/openalex/models/funder.py
@@ -115,17 +115,25 @@ class Funder(OpenAlexEntity):
 
     def works_in_year(self, year: int) -> int:
         """Return number of works funded in a specific year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.works_count
-        return 0
+        return next(
+            (
+                year_data.works_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def citations_in_year(self, year: int) -> int:
         """Return citation count for a specific year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.cited_by_count
-        return 0
+        return next(
+            (
+                year_data.cited_by_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def active_years(self) -> list[int]:
         """Return list of years with grant activity."""

--- a/openalex/models/institution.py
+++ b/openalex/models/institution.py
@@ -251,17 +251,25 @@ class Institution(OpenAlexEntity):
 
     def works_in_year(self, year: int) -> int:
         """Return works count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.works_count
-        return 0
+        return next(
+            (
+                year_data.works_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def citations_in_year(self, year: int) -> int:
         """Return citation count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.cited_by_count
-        return 0
+        return next(
+            (
+                year_data.cited_by_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def active_years(self) -> list[int]:
         """Return list of years with publications."""

--- a/openalex/models/publisher.py
+++ b/openalex/models/publisher.py
@@ -86,17 +86,25 @@ class Publisher(OpenAlexEntity):
 
     def works_in_year(self, year: int) -> int:
         """Return works count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.works_count
-        return 0
+        return next(
+            (
+                year_data.works_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def citations_in_year(self, year: int) -> int:
         """Return citation count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.cited_by_count
-        return 0
+        return next(
+            (
+                year_data.cited_by_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def active_years(self) -> list[int]:
         """Return list of years with publications."""

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -182,17 +182,25 @@ class Source(OpenAlexEntity):
 
     def works_in_year(self, year: int) -> int:
         """Return works count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.works_count
-        return 0
+        return next(
+            (
+                year_data.works_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def citations_in_year(self, year: int) -> int:
         """Return citation count for a given year."""
-        for year_data in self.counts_by_year:
-            if year_data.year == year:
-                return year_data.cited_by_count
-        return 0
+        return next(
+            (
+                year_data.cited_by_count
+                for year_data in self.counts_by_year
+                if year_data.year == year
+            ),
+            0,
+        )
 
     def active_years(self) -> list[int]:
         """Return list of years with publication activity."""

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -17,6 +17,7 @@ from pydantic import (
     model_validator,
 )
 
+from ..constants import MAX_SECONDS_IN_MINUTE
 from .base import OpenAlexBase, OpenAlexEntity, SummaryStats
 
 
@@ -104,7 +105,7 @@ class Topic(OpenAlexEntity):
                 )
                 if match:
                     sec = int(match.group("sec"))
-                    sec = min(sec, 59)
+                    sec = min(sec, MAX_SECONDS_IN_MINUTE)
                     new_v = f"{match.group('prefix')}:{sec:02d}{match.group('rest')}"
                     try:
                         return datetime.fromisoformat(new_v)

--- a/openalex/resources/authors.py
+++ b/openalex/resources/authors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..constants import MAG_PREFIX, ORCID_URL_PREFIX
 from ..models import Author, AuthorsFilter, ListResult
 from ..utils import ensure_prefix, strip_id_prefix
 from ..utils.pagination import MAX_PER_PAGE
@@ -41,8 +42,8 @@ class AuthorsResource(BaseResource[Author, AuthorsFilter]):
 
     def by_mag(self, mag_id: str) -> Author:
         """Get author by Microsoft Academic Graph ID."""
-        if not str(mag_id).startswith("mag:"):
-            mag_id = f"mag:{mag_id}"
+        if not str(mag_id).startswith(MAG_PREFIX):
+            mag_id = f"{MAG_PREFIX}{mag_id}"
         return self.get(mag_id)
 
     def by_institution(self, institution_id: str) -> AuthorsResource:
@@ -94,7 +95,7 @@ class AuthorsResource(BaseResource[Author, AuthorsFilter]):
         Returns:
             Author instance
         """
-        return self.get(ensure_prefix(orcid, "https://orcid.org/"))
+        return self.get(ensure_prefix(orcid, ORCID_URL_PREFIX))
 
 
 class AsyncAuthorsResource(AsyncBaseResource[Author, AuthorsFilter]):
@@ -124,8 +125,8 @@ class AsyncAuthorsResource(AsyncBaseResource[Author, AuthorsFilter]):
 
     async def by_mag(self, mag_id: str) -> Author:
         """Get author by Microsoft Academic Graph ID."""
-        if not str(mag_id).startswith("mag:"):
-            mag_id = f"mag:{mag_id}"
+        if not str(mag_id).startswith(MAG_PREFIX):
+            mag_id = f"{MAG_PREFIX}{mag_id}"
         return await self.get(mag_id)
 
     async def by_institution(self, institution_id: str) -> AsyncAuthorsResource:
@@ -177,4 +178,4 @@ class AsyncAuthorsResource(AsyncBaseResource[Author, AuthorsFilter]):
         Returns:
             Author instance
         """
-        return await self.get(ensure_prefix(orcid, "https://orcid.org/"))
+        return await self.get(ensure_prefix(orcid, ORCID_URL_PREFIX))

--- a/openalex/resources/base.py
+++ b/openalex/resources/base.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 from pydantic import ValidationError
 from structlog import get_logger
 
+from ..constants import OPENALEX_ID_PREFIX
 from ..exceptions import ValidationError as OpenAlexValidationError
 from ..exceptions import raise_for_status
 from ..models import BaseFilter, ListResult
@@ -114,8 +115,8 @@ class BaseResource(Generic[T, F]):
             Entity model instance
         """
         # Remove OpenAlex prefix if present but keep full IDs like ORCID/ROR
-        if id.startswith("https://openalex.org/"):
-            id = id.rsplit("/", 1)[-1]
+        if id.startswith(OPENALEX_ID_PREFIX):
+            id = id[len(OPENALEX_ID_PREFIX) :]
 
         url = self._build_url(id)
         response = self.client._request("GET", url, params=params)  # noqa: SLF001
@@ -329,8 +330,8 @@ class AsyncBaseResource(Generic[T, F]):
 
     async def get(self, id: str, **params: Any) -> T:
         """Get a single entity by ID."""
-        if id.startswith("https://openalex.org/"):
-            id = id.rsplit("/", 1)[-1]
+        if id.startswith(OPENALEX_ID_PREFIX):
+            id = id[len(OPENALEX_ID_PREFIX) :]
 
         url = self._build_url(id)
         response = await self.client._request("GET", url, params=params)  # noqa: SLF001

--- a/openalex/resources/works.py
+++ b/openalex/resources/works.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
+from ..constants import DOI_URL_PREFIX, PMID_PREFIX
 from ..models import ListResult, Work, WorksFilter
 from ..utils import ensure_prefix, strip_id_prefix
 from ..utils.pagination import MAX_PER_PAGE
@@ -33,12 +34,12 @@ class WorksResource(BaseResource[Work, WorksFilter]):
     def by_doi(self, doi: str) -> Work:
         """Retrieve a work by DOI."""
 
-        return self.get(ensure_prefix(doi, "https://doi.org/"))
+        return self.get(ensure_prefix(doi, DOI_URL_PREFIX))
 
     def by_pmid(self, pmid: str) -> Work:
         """Retrieve a work by PubMed ID."""
 
-        return self.get(ensure_prefix(str(pmid), "pmid:"))
+        return self.get(ensure_prefix(str(pmid), PMID_PREFIX))
 
     def filter(self, **filter_params: Any) -> Self | WorksFilter:
         """Add filter parameters or return a ``WorksFilter`` builder.
@@ -221,12 +222,12 @@ class AsyncWorksResource(AsyncBaseResource[Work, WorksFilter]):
     async def by_doi(self, doi: str) -> Work:
         """Retrieve a work by DOI."""
 
-        return await self.get(ensure_prefix(doi, "https://doi.org/"))
+        return await self.get(ensure_prefix(doi, DOI_URL_PREFIX))
 
     async def by_pmid(self, pmid: str) -> Work:
         """Retrieve a work by PubMed ID."""
 
-        return await self.get(ensure_prefix(str(pmid), "pmid:"))
+        return await self.get(ensure_prefix(str(pmid), PMID_PREFIX))
 
     def _clone_with(self, filter_update: dict[str, Any]) -> Self:
         base_filter = self._default_filter or WorksFilter.model_validate({})

--- a/openalex/utils/__init__.py
+++ b/openalex/utils/__init__.py
@@ -1,5 +1,12 @@
 """Utility functions and classes for OpenAlex client."""
 
+from ..constants import (
+    DOI_URL_PREFIX,
+    MAG_PREFIX,
+    OPENALEX_ID_PREFIX,
+    ORCID_URL_PREFIX,
+    PMID_PREFIX,
+)
 from .common import ensure_prefix, normalize_params, strip_id_prefix
 from .pagination import AsyncPaginator, Paginator
 from .rate_limit import (
@@ -18,6 +25,11 @@ from .retry import (
 )
 
 __all__ = [
+    "DOI_URL_PREFIX",
+    "MAG_PREFIX",
+    "OPENALEX_ID_PREFIX",
+    "ORCID_URL_PREFIX",
+    "PMID_PREFIX",
     "AsyncPaginator",
     "AsyncRateLimiter",
     "Paginator",

--- a/openalex/utils/common.py
+++ b/openalex/utils/common.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["ensure_prefix", "normalize_params", "strip_id_prefix"]
+from ..constants import OPENALEX_ID_PREFIX
+
+__all__ = [
+    "OPENALEX_ID_PREFIX",
+    "ensure_prefix",
+    "normalize_params",
+    "strip_id_prefix",
+]
 
 
 KEY_MAP = {"per_page": "per-page", "group_by": "group-by"}
@@ -22,8 +29,10 @@ def normalize_params(params: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def strip_id_prefix(value: str) -> str:
-    """Remove URL style prefixes from an OpenAlex identifier."""
+def strip_id_prefix(value: str, prefix: str = OPENALEX_ID_PREFIX) -> str:
+    """Remove URL-style prefix from an OpenAlex identifier."""
+    if value.startswith(prefix):
+        return value[len(prefix) :]
     return value.rsplit("/", 1)[-1]
 
 


### PR DESCRIPTION
## Summary
- centralize string constants in `openalex.constants`
- replace magic strings across resources
- simplify yearly lookup helpers with `next`
- fix stray loops and update config
- expose constants via `openalex.utils`

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68469af08f0c832b8215b9f230854e03