### PR TITLE
Refactor constants and cleanup

### DIFF
--- a/openalex/client.py
+++ b/openalex/client.py
@@ -17,7 +17,7 @@ import httpx
 from structlog import get_logger
 
 from .config import OpenAlexConfig
-from .constants import DEFAULT_RATE_LIMIT
+from .constants import DEFAULT_RATE_LIMIT, HTTP_METHOD_GET, REQUEST_FAILED_MSG
 from .exceptions import NetworkError, TimeoutError
 from .models import AutocompleteResult, ListResult
 from .resources import (
@@ -198,8 +198,7 @@ class OpenAlex:
         if last_error:
             raise last_error
 
-        msg = "Request failed after all retries"
-        raise NetworkError(msg)
+        raise NetworkError(REQUEST_FAILED_MSG)
 
     def autocomplete(
         self,
@@ -224,7 +223,7 @@ class OpenAlex:
         else:
             url = f"{self.base_url}/autocomplete"
 
-        response = self._request("GET", url, params=params)
+        response = self._request(HTTP_METHOD_GET, url, params=params)
         response.raise_for_status()
 
         data = response.json()
@@ -263,7 +262,7 @@ class OpenAlex:
         if entity_type:
             url = f"{url}/{entity_type}"
 
-        response = self._request("GET", url, params=params)
+        response = self._request(HTTP_METHOD_GET, url, params=params)
         response.raise_for_status()
 
         return cast("dict[str, Any]", response.json())
@@ -454,8 +453,7 @@ class AsyncOpenAlex:
         if last_error:
             raise last_error
 
-        msg = "Request failed after all retries"
-        raise NetworkError(msg)
+        raise NetworkError(REQUEST_FAILED_MSG)
 
     async def autocomplete(
         self,
@@ -480,7 +478,7 @@ class AsyncOpenAlex:
         else:
             url = f"{self.base_url}/autocomplete"
 
-        response = await self._request("GET", url, params=params)
+        response = await self._request(HTTP_METHOD_GET, url, params=params)
         response.raise_for_status()
 
         data = response.json()
@@ -509,7 +507,7 @@ class AsyncOpenAlex:
         if entity_type:
             url = f"{url}/{entity_type}"
 
-        response = await self._request("GET", url, params=params)
+        response = await self._request(HTTP_METHOD_GET, url, params=params)
         response.raise_for_status()
 
         return cast("dict[str, Any]", response.json())

--- a/openalex/config.py
+++ b/openalex/config.py
@@ -9,6 +9,16 @@ __all__ = ["OpenAlexConfig"]
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from . import __version__
+from .constants import (
+    DEFAULT_BASE_URL,
+    DEFAULT_CACHE_TTL,
+    DEFAULT_PER_PAGE,
+    DEFAULT_TIMEOUT,
+    HEADER_ACCEPT,
+    HEADER_ACCEPT_ENCODING,
+    HEADER_AUTHORIZATION,
+    HEADER_USER_AGENT,
+)
 from .utils.rate_limit import DEFAULT_BUFFER
 
 
@@ -16,7 +26,7 @@ class OpenAlexConfig(BaseModel):
     """Configuration for OpenAlex API client."""
 
     base_url: HttpUrl = Field(
-        default=HttpUrl("https://api.openalex.org"),
+        default=DEFAULT_BASE_URL,
         description="Base URL for the OpenAlex API",
     )
     email: str | None = Field(
@@ -28,13 +38,13 @@ class OpenAlexConfig(BaseModel):
         description="Premium API key for higher rate limits",
     )
     timeout: float = Field(
-        default=30.0,
+        default=DEFAULT_TIMEOUT,
         gt=0,
         le=300,
         description="Request timeout in seconds",
     )
     per_page: int = Field(
-        default=200,
+        default=DEFAULT_PER_PAGE,
         ge=1,
         le=200,
         description="Default items per page",
@@ -48,7 +58,7 @@ class OpenAlexConfig(BaseModel):
         description="Enable response caching",
     )
     cache_ttl: int = Field(
-        default=3600,
+        default=DEFAULT_CACHE_TTL,
         ge=0,
         description="Cache TTL in seconds",
     )
@@ -69,8 +79,8 @@ class OpenAlexConfig(BaseModel):
     def headers(self) -> dict[str, str]:
         """Get default headers for requests."""
         headers: dict[str, str] = {
-            "Accept": "application/json",
-            "Accept-Encoding": "gzip, deflate",
+            HEADER_ACCEPT: "application/json",
+            HEADER_ACCEPT_ENCODING: "gzip, deflate",
         }
 
         # Build user agent
@@ -79,11 +89,11 @@ class OpenAlexConfig(BaseModel):
             ua_parts.append(f"(mailto:{self.email})")
         if self.user_agent:
             ua_parts.append(self.user_agent)
-        headers["User-Agent"] = " ".join(ua_parts)
+        headers[HEADER_USER_AGENT] = " ".join(ua_parts)
 
         # Add API key if provided
         if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+            headers[HEADER_AUTHORIZATION] = f"Bearer {self.api_key}"
 
         return headers
 

--- a/openalex/constants.py
+++ b/openalex/constants.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from http import HTTPStatus
 
+from pydantic import HttpUrl
+
 OPENALEX_ID_PREFIX = "https://openalex.org/"
 ORCID_URL_PREFIX = "https://orcid.org/"
 DOI_URL_PREFIX = "https://doi.org/"
@@ -13,6 +15,16 @@ MAG_PREFIX = "mag:"
 MAX_SECONDS_IN_MINUTE = 59
 
 DEFAULT_RATE_LIMIT = 10.0
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_PER_PAGE = 200
+DEFAULT_CACHE_TTL = 3600
+REQUEST_FAILED_MSG = "Request failed after all retries"
+DEFAULT_BASE_URL = HttpUrl("https://api.openalex.org")
+HTTP_METHOD_GET = "GET"
+HEADER_ACCEPT = "Accept"
+HEADER_ACCEPT_ENCODING = "Accept-Encoding"
+HEADER_AUTHORIZATION = "Authorization"
+HEADER_USER_AGENT = "User-Agent"
 
 HTTP_TOO_MANY_REQUESTS = HTTPStatus.TOO_MANY_REQUESTS
 HTTP_UNAUTHORIZED = HTTPStatus.UNAUTHORIZED
@@ -20,8 +32,17 @@ HTTP_NOT_FOUND = HTTPStatus.NOT_FOUND
 HTTP_SERVER_ERROR_BOUNDARY = HTTPStatus.INTERNAL_SERVER_ERROR
 
 __all__ = [
+    "DEFAULT_BASE_URL",
+    "DEFAULT_CACHE_TTL",
+    "DEFAULT_PER_PAGE",
     "DEFAULT_RATE_LIMIT",
+    "DEFAULT_TIMEOUT",
     "DOI_URL_PREFIX",
+    "HEADER_ACCEPT",
+    "HEADER_ACCEPT_ENCODING",
+    "HEADER_AUTHORIZATION",
+    "HEADER_USER_AGENT",
+    "HTTP_METHOD_GET",
     "HTTP_NOT_FOUND",
     "HTTP_SERVER_ERROR_BOUNDARY",
     "HTTP_TOO_MANY_REQUESTS",
@@ -31,4 +52,5 @@ __all__ = [
     "OPENALEX_ID_PREFIX",
     "ORCID_URL_PREFIX",
     "PMID_PREFIX",
+    "REQUEST_FAILED_MSG",
 ]

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -18,6 +18,10 @@ from pydantic import (
 )
 
 from ..constants import MAX_SECONDS_IN_MINUTE
+
+MALFORMED_DATETIME_REGEX = re.compile(
+    r"(?P<prefix>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}):(?P<sec>\d{2})(?P<rest>.*)"
+)
 from .base import OpenAlexBase, OpenAlexEntity, SummaryStats
 
 
@@ -99,10 +103,7 @@ class Topic(OpenAlexEntity):
             try:
                 return cast("datetime", parser.parse(v))
             except (ValueError, TypeError):
-                match = re.match(
-                    r"(?P<prefix>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}):(?P<sec>\d{2})(?P<rest>.*)",
-                    v,
-                )
+                match = MALFORMED_DATETIME_REGEX.match(v)
                 if match:
                     sec = int(match.group("sec"))
                     sec = min(sec, MAX_SECONDS_IN_MINUTE)

--- a/openalex/resources/authors.py
+++ b/openalex/resources/authors.py
@@ -32,6 +32,7 @@ class AuthorsResource(BaseResource[Author, AuthorsFilter]):
         self._default_filter = default_filter
 
     def _clone_with(self, filter_update: dict[str, Any]) -> AuthorsResource:
+        """Return a new resource with ``filter_update`` merged."""
         base_filter = self._default_filter or AuthorsFilter.model_validate({})
         current = base_filter.filter or {}
         if isinstance(current, str):
@@ -115,6 +116,7 @@ class AsyncAuthorsResource(AsyncBaseResource[Author, AuthorsFilter]):
     def _clone_with(
         self, filter_update: dict[str, Any]
     ) -> AsyncAuthorsResource:
+        """Return a new async resource with ``filter_update`` merged."""
         base_filter = self._default_filter or AuthorsFilter.model_validate({})
         current = base_filter.filter or {}
         if isinstance(current, str):

--- a/openalex/utils/rate_limit.py
+++ b/openalex/utils/rate_limit.py
@@ -216,7 +216,7 @@ class AsyncRateLimiter:
 
     async def __aexit__(self, *args: Any) -> None:
         """Context manager exit."""
-        return
+        return None
 
 
 def rate_limited(


### PR DESCRIPTION
## Summary
- centralize common defaults and header names in `constants.py`
- use new constants in configuration
- use constants for request method and failure message in client
- improve parsing in `Topic` model and document resource helpers
- fix async rate limiter context exit

## Testing
- `ruff format .`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a00749d4832bb0d2cea8438a7a0b