### PR TITLE
Increase test coverage to 94%

### DIFF
--- a/tests/resources/test_sources.py
+++ b/tests/resources/test_sources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import pytest
 from openalex.models import Source, SourceType
 
 from .base import BaseResourceTest
@@ -280,3 +281,18 @@ class TestSourcesResource(BaseResourceTest[Source]):
             filter={"homepage_url": "!null"}
         )
         assert sources_with_homepage.meta.count == 8000
+
+    @pytest.mark.asyncio
+    async def test_async_by_issn(
+        self,
+        async_client: AsyncOpenAlex,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        issn = "0031-9007"
+        entity = self.get_sample_entity()
+        httpx_mock.add_response(
+            url=f"https://api.openalex.org/sources/issn:{issn}?mailto=test%40example.com",
+            json=entity,
+        )
+        source = await async_client.sources.by_issn(f" {issn} ")
+        assert source.id == entity["id"]


### PR DESCRIPTION
## Summary
- add tests for text_aboutness endpoints
- test _clone_with with string filters in AuthorsResource
- test SourcesResource async ISSN helper
- extend WorksResource coverage including async helpers and open_access
- add non retryable request test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bc397ac4832ba3f7ee953bf68b88