### PR TITLE
Improve test coverage

### DIFF
--- a/tests/models/test_base_model.py
+++ b/tests/models/test_base_model.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import HttpUrl
+else:
+    HttpUrl = str
+
+
+from openalex.models.base import OpenAlexBase
+
+
+class DummyModel(OpenAlexBase):
+    dt: datetime
+    d: date
+    url: HttpUrl
+
+
+def test_openalexbase_serialization() -> None:
+    obj = DummyModel(
+        dt=datetime(2024, 1, 1, 12, 0, 0),
+        d=date(2024, 1, 1),
+        url="https://example.com",
+    )
+    data = obj.model_dump(mode="json")
+    assert data["dt"] == "2024-01-01 12:00:00"
+    assert data["d"] == "2024-01-01"
+    assert data["url"] == "https://example.com"

--- a/tests/resources/base.py
+++ b/tests/resources/base.py
@@ -474,3 +474,20 @@ class BaseResourceTest(Generic[T]):
         result = await resource.autocomplete("test")
         assert result.meta.count == 3
         assert len(result.results) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_get_with_full_url(
+        self,
+        async_client: AsyncOpenAlex,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        entity_data = self.get_sample_entity()
+        full_url = f"https://openalex.org/{self.sample_id}"
+        httpx_mock.add_response(
+            url=f"https://api.openalex.org/{self.resource_name}/{self.sample_id}?mailto=test%40example.com",
+            json=entity_data,
+        )
+        resource = self.get_async_resource(async_client)
+        entity = await resource.get(full_url)
+        assert entity.id == entity_data["id"]
+

--- a/tests/resources/test_authors.py
+++ b/tests/resources/test_authors.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
+
 from openalex.models import Author, AuthorsFilter
-from openalex.resources import AuthorsResource, AsyncAuthorsResource
+from openalex.resources import AsyncAuthorsResource, AuthorsResource
 
 from .base import BaseResourceTest
 
@@ -381,3 +382,16 @@ class TestAuthorsResource(BaseResourceTest[Author]):
         new_res = await resource.by_institution("I123")
         result = await new_res.list()
         assert result.meta.count == 100
+
+
+def test_filter_builder_authors(client: OpenAlex) -> None:
+    filt = client.authors.filter(page=2)
+    assert isinstance(filt, AuthorsFilter)
+    assert filt.page == 2
+
+@pytest.mark.asyncio
+async def test_async_filter_builder_authors(async_client: AsyncOpenAlex) -> None:
+    filt = async_client.authors.filter(page=2)
+    assert isinstance(filt, AuthorsFilter)
+    assert filt.page == 2
+


### PR DESCRIPTION
## Summary
- add tests for OpenAlexBase serialization
- expand async resource coverage
- add additional client tests
- add filter builder tests for authors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bfb73c20832b98a321a1e8586e6a