### PR TITLE
Add docs for grouping works

### DIFF
--- a/docs/filter-works.md
+++ b/docs/filter-works.md
@@ -1,0 +1,66 @@
+# Filter works
+
+Use the `filter` argument of `client.works.list()` to narrow results. Filter
+keys follow the same names as the API.
+
+```python
+from openalex import OpenAlex
+
+client = OpenAlex()
+# works published in 2020
+works = client.works.list(filter={"publication_year": 2020})
+```
+
+Multiple filters can be combined by passing a dictionary:
+
+```python
+params = {"publication_year": 2020, "is_oa": True}
+works = client.works.list(filter=params)
+```
+
+For more complex queries you can build a `WorksFilter` object:
+
+```python
+from openalex import WorksFilter
+
+filt = WorksFilter().with_publication_year(2020).with_open_access()
+works = client.works.list(filter=filt)
+```
+
+## Attribute filters
+
+Attribute filters match fields on the `Work` object. Pass them as a
+dictionary or use helper methods on `WorksFilter`.
+
+```python
+# by author and work type
+params = {"authorships.author.id": "A123456789", "type": "article"}
+results = client.works.list(filter=params)
+
+filt = WorksFilter().with_author_id("A123456789").with_type("article")
+results = client.works.list(filter=filt)
+```
+
+Other common attribute filters include `publication_year`, `concepts.id`, and
+`primary_location.source.id`.
+
+## Convenience filters
+
+Convenience filters offer shortcuts for frequent queries that are not direct
+properties of the work record.
+
+```python
+# works that cite a specific paper and have an abstract
+params = {"cites": "W2741809807", "has_abstract": True}
+results = client.works.list(filter=params)
+
+filt = WorksFilter().with_cites("W2741809807").with_has_abstract(True)
+results = client.works.list(filter=filt)
+```
+
+Other examples are `from_publication_date`, `has_fulltext`, and
+`best_open_version`.
+
+For a complete list of available filters see the [OpenAlex API
+documentation](https://docs.openalex.org/api-entities/works/filter-works).
+

--- a/docs/get-a-single-work.md
+++ b/docs/get-a-single-work.md
@@ -1,0 +1,46 @@
+# Get a single work
+
+Use the client to fetch a `Work` by its OpenAlex identifier.
+
+```python
+from openalex import OpenAlex
+
+client = OpenAlex()
+work = client.works.get("W2741809807")
+print(work.display_name)
+```
+
+To look up several works in one request, pass their IDs as a filter:
+
+```python
+ids = ["W2741809807", "W2100837269"]
+works = client.works.list(filter={"id": ids})
+```
+
+## External IDs
+
+Works can also be retrieved by other identifiers such as DOIs or PubMed IDs.
+
+```python
+work = client.works.by_doi("10.7717/peerj.4375")
+work = client.works.get("pmid:14907713")
+```
+
+Supported prefixes:
+
+| External ID | Prefix |
+|-------------|-------|
+| DOI | `doi:` |
+| Microsoft Academic Graph (MAG) | `mag:` |
+| PubMed ID (PMID) | `pmid:` |
+| PubMed Central ID (PMCID) | `pmcid:` |
+
+Make sure the identifier is valid. Invalid or malformed IDs will either return no result or raise an error.
+
+### Select fields
+
+Return only the fields you need using `select`:
+
+```python
+work = client.works.get("W2741809807", select=["id", "display_name"])
+```

--- a/docs/get-lists-of-works.md
+++ b/docs/get-lists-of-works.md
@@ -1,0 +1,41 @@
+# Get lists of works
+
+`client.works.list()` returns batches of works along with metadata.
+
+```python
+from openalex import OpenAlex
+
+client = OpenAlex()
+works = client.works.list()
+print(works.meta.count)
+```
+
+## Page and sort works
+
+Control pagination and ordering with parameters:
+
+```python
+# Second page with 50 items
+page2 = client.works.list(per_page=50, page=2)
+
+# Sort by publication year
+sorted_works = client.works.list(sort="publication_year")
+```
+
+## Sample works
+
+Request a random sample of works:
+
+```python
+sample = client.works.list(sample=20)
+```
+
+## Select fields
+
+Return only chosen fields from each work:
+
+```python
+minimal = client.works.list(select=["id", "display_name"])
+```
+
+Filtering and searching are covered in their own guides.

--- a/docs/group-works.md
+++ b/docs/group-works.md
@@ -1,0 +1,22 @@
+# Group works
+
+Use `group_by` to aggregate works by a given field.
+
+```python
+from openalex import OpenAlex
+
+client = OpenAlex()
+# count works for each open access status
+result = client.works.list(group_by="oa_status")
+for group in result.group_by:
+    print(group.key, group.count)
+```
+
+You can combine grouping with filters or other parameters via the query builder:
+
+```python
+query = client.works.query().filter(is_oa=True).group_by("publication_year")
+result = query.list()
+```
+
+See the [OpenAlex API documentation](https://docs.openalex.org/api-entities/works/group-works) for the full list of supported group-by attributes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# OpenAlex Python Client Documentation
+
+Short examples showing how to accomplish common tasks with the Python client.
+
+- [Get a single work](get-a-single-work.md)
+- [Get lists of works](get-lists-of-works.md)
+- [Filter works](filter-works.md)
+- [Search works](search-works.md)
+- [Group works](group-works.md)
+

--- a/docs/search-works.md
+++ b/docs/search-works.md
@@ -1,0 +1,55 @@
+# Search works
+
+Use `client.works.search()` to query titles, abstracts, and full text.
+
+```python
+from openalex import OpenAlex
+
+client = OpenAlex()
+results = client.works.search("dna")
+print(results.results[0].display_name)
+```
+
+Full text search only applies to works where `has_fulltext` is true.
+
+See the [OpenAlex documentation](https://docs.openalex.org/api-entities/works/search-works) for details on how search ranking works and more advanced options.
+
+## Search a specific field
+
+Append `.search` to a filter key to limit searching to that field:
+
+```python
+works = client.works.list(filter={"title.search": "cubist"})
+```
+
+Fields that accept `.search` include `abstract`, `display_name` (alias `title`), `fulltext`, `raw_affiliation_strings`, and `title_and_abstract`. You can also use `default.search`, which behaves the same as the `search` parameter.
+
+| Search filter | Field that is searched |
+| --- | --- |
+| `abstract.search` | `abstract_inverted_index` |
+| `display_name.search` | `display_name` |
+| `fulltext.search` | fulltext via n-grams |
+| `raw_affiliation_strings.search` | `authorships.raw_affiliation_strings` |
+| `title.search` | `display_name` |
+| `title_and_abstract.search` | `display_name` and `abstract_inverted_index` |
+
+These searches apply stemming and stop-word removal. See the API docs if you need to disable this behaviour.
+
+### Searching by related entity names
+
+To search works by a related entity like an author or institution, first lookup that entity and then filter works by its ID:
+
+```python
+nyu = client.institutions.search("nyu").results[0]
+works = client.works.list(filter={"institutions.id": nyu.id})
+```
+
+## Autocomplete works
+
+`client.works.autocomplete()` provides typeahead suggestions:
+
+```python
+suggestions = client.works.autocomplete("tigers")
+```
+
+Each suggestion includes the title and a hint containing the authors.


### PR DESCRIPTION
## Summary
- expand doc index with group-by page
- document grouping works by a field using the client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846fc48e6ec832b9cef3fd1d82d8209