### PR TITLE
Refactor constants and remove magic numbers

### DIFF
--- a/openalex/client.py
+++ b/openalex/client.py
@@ -26,6 +26,7 @@ from .constants import (
     PARAM_Q,
     REQUEST_FAILED_MSG,
     TEXT_PATH,
+    Resource,
 )
 from .exceptions import NetworkError, TimeoutError
 from .models import AutocompleteResult, ListResult
@@ -64,17 +65,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-SEARCH_ALL_RESOURCE_NAMES: Final[list[str]] = [
-    "works",
-    "authors",
-    "institutions",
-    "sources",
-    "concepts",
-    "topics",
-    "publishers",
-    "funders",
-    "keywords",
-]
+SEARCH_ALL_RESOURCE_NAMES: Final[list[str]] = [r.value for r in Resource]
 SEARCH_ALL_RESOURCES: Final[list[tuple[str, str]]] = [
     (name, name) for name in SEARCH_ALL_RESOURCE_NAMES
 ]

--- a/openalex/config.py
+++ b/openalex/config.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from . import __version__
 from .constants import (
+    ACCEPT_ENCODING_GZIP,
+    ACCEPT_JSON,
     DEFAULT_BASE_URL,
     DEFAULT_CACHE_TTL,
     DEFAULT_PER_PAGE,
@@ -79,8 +81,8 @@ class OpenAlexConfig(BaseModel):
     def headers(self) -> dict[str, str]:
         """Get default headers for requests."""
         headers: dict[str, str] = {
-            HEADER_ACCEPT: "application/json",
-            HEADER_ACCEPT_ENCODING: "gzip, deflate",
+            HEADER_ACCEPT: ACCEPT_JSON,
+            HEADER_ACCEPT_ENCODING: ACCEPT_ENCODING_GZIP,
         }
 
         # Build user agent

--- a/openalex/constants.py
+++ b/openalex/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from http import HTTPStatus
 
 from pydantic import HttpUrl
@@ -11,6 +12,7 @@ ORCID_URL_PREFIX = "https://orcid.org/"
 DOI_URL_PREFIX = "https://doi.org/"
 PMID_PREFIX = "pmid:"
 MAG_PREFIX = "mag:"
+ROR_URL_PREFIX = "https://ror.org/"
 
 SECONDS_PER_MINUTE = 60
 MINUTES_PER_HOUR = 60
@@ -21,6 +23,9 @@ DEFAULT_TIMEOUT = 30.0
 DEFAULT_PER_PAGE = 200
 DEFAULT_CACHE_TTL = 3600
 DEFAULT_CONCURRENCY = 5
+FIRST_PAGE = 1
+SINGLE_PER_PAGE = 1
+FILTER_DEFAULT_PER_PAGE = 25
 REQUEST_FAILED_MSG = "Request failed after all retries"
 DEFAULT_BASE_URL = HttpUrl("https://api.openalex.org")
 HTTP_METHOD_GET = "GET"
@@ -28,6 +33,8 @@ HEADER_ACCEPT = "Accept"
 HEADER_ACCEPT_ENCODING = "Accept-Encoding"
 HEADER_AUTHORIZATION = "Authorization"
 HEADER_USER_AGENT = "User-Agent"
+ACCEPT_JSON = "application/json"
+ACCEPT_ENCODING_GZIP = "gzip, deflate"
 PARAM_Q = "q"
 PARAM_CURSOR = "cursor"
 PARAM_PAGE = "page"
@@ -36,6 +43,22 @@ AUTOCOMPLETE_PATH = "autocomplete"
 RANDOM_PATH = "random"
 TEXT_PATH = "text"
 UNREACHABLE_MSG = "Unreachable"
+
+
+class Resource(str, Enum):
+    """Enumeration of OpenAlex resource endpoints."""
+
+    WORKS = "works"
+    AUTHORS = "authors"
+    INSTITUTIONS = "institutions"
+    SOURCES = "sources"
+    CONCEPTS = "concepts"
+    TOPICS = "topics"
+    PUBLISHERS = "publishers"
+    FUNDERS = "funders"
+    KEYWORDS = "keywords"
+
+
 GOVERNMENT_KEYWORDS = [
     "national",
     "federal",
@@ -50,6 +73,8 @@ HTTP_NOT_FOUND = HTTPStatus.NOT_FOUND
 HTTP_SERVER_ERROR_BOUNDARY = HTTPStatus.INTERNAL_SERVER_ERROR
 
 __all__ = [
+    "ACCEPT_ENCODING_GZIP",
+    "ACCEPT_JSON",
     "AUTOCOMPLETE_PATH",
     "DEFAULT_BASE_URL",
     "DEFAULT_CACHE_TTL",
@@ -58,6 +83,8 @@ __all__ = [
     "DEFAULT_RATE_LIMIT",
     "DEFAULT_TIMEOUT",
     "DOI_URL_PREFIX",
+    "FILTER_DEFAULT_PER_PAGE",
+    "FIRST_PAGE",
     "GOVERNMENT_KEYWORDS",
     "HEADER_ACCEPT",
     "HEADER_ACCEPT_ENCODING",
@@ -80,7 +107,10 @@ __all__ = [
     "PMID_PREFIX",
     "RANDOM_PATH",
     "REQUEST_FAILED_MSG",
+    "ROR_URL_PREFIX",
     "SECONDS_PER_MINUTE",
+    "SINGLE_PER_PAGE",
     "TEXT_PATH",
     "UNREACHABLE_MSG",
+    "Resource",
 ]

--- a/openalex/models/base.py
+++ b/openalex/models/base.py
@@ -8,6 +8,8 @@ from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer
 
+from ..constants import FILTER_DEFAULT_PER_PAGE, FIRST_PAGE
+
 
 class EntityType(str, Enum):
     """OpenAlex entity types."""
@@ -105,8 +107,10 @@ class Meta(OpenAlexBase):
 
     count: int = Field(..., description="Total count of results")
     db_response_time_ms: int = Field(..., description="Database response time")
-    page: int = Field(1, description="Current page")
-    per_page: int = Field(25, description="Results per page")
+    page: int = Field(FIRST_PAGE, description="Current page")
+    per_page: int = Field(
+        FILTER_DEFAULT_PER_PAGE, description="Results per page"
+    )
     groups_count: int | None = Field(None, description="Number of groups")
     next_cursor: str | None = Field(None, description="Cursor for next page")
 

--- a/openalex/models/filters.py
+++ b/openalex/models/filters.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from ..constants import FILTER_DEFAULT_PER_PAGE, FIRST_PAGE
+
 
 class SortOrder(str, Enum):
     """Sort order options."""
@@ -41,13 +43,13 @@ class BaseFilter(BaseModel):
     sort: str | None = Field(None, description="Sort field")
     group_by: str | GroupBy | None = Field(None, description="Group by field")
     page: int | None = Field(
-        default=1,
+        default=FIRST_PAGE,
         ge=1,
         le=10000,
         description="Page number",
     )
     per_page: int | None = Field(
-        default=25,
+        default=FILTER_DEFAULT_PER_PAGE,
         ge=1,
         le=200,
         description="Results per page",

--- a/openalex/resources/authors.py
+++ b/openalex/resources/authors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..constants import MAG_PREFIX, ORCID_URL_PREFIX
+from ..constants import MAG_PREFIX, ORCID_URL_PREFIX, Resource
 from ..models import Author, AuthorsFilter, ListResult
 from ..utils import ensure_prefix, strip_id_prefix
 from ..utils.pagination import MAX_PER_PAGE
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class AuthorsResource(BaseResource[Author, AuthorsFilter]):
     """Resource for accessing authors endpoints."""
 
-    endpoint = "authors"
+    endpoint = Resource.AUTHORS.value
     model_class = Author
     filter_class = AuthorsFilter
 
@@ -102,7 +102,7 @@ class AuthorsResource(BaseResource[Author, AuthorsFilter]):
 class AsyncAuthorsResource(AsyncBaseResource[Author, AuthorsFilter]):
     """Async resource for accessing authors endpoints."""
 
-    endpoint = "authors"
+    endpoint = Resource.AUTHORS.value
     model_class = Author
     filter_class = AuthorsFilter
 

--- a/openalex/resources/concepts.py
+++ b/openalex/resources/concepts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import Resource
 from ..models import BaseFilter, Concept
 from ..utils import ensure_prefix
 from .base import AsyncBaseResource, BaseResource
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class ConceptsResource(BaseResource[Concept, BaseFilter]):
     """Resource for accessing concepts endpoints."""
 
-    endpoint = "concepts"
+    endpoint = Resource.CONCEPTS.value
     model_class = Concept
     filter_class = BaseFilter
 
@@ -48,7 +49,7 @@ class ConceptsResource(BaseResource[Concept, BaseFilter]):
 class AsyncConceptsResource(AsyncBaseResource[Concept, BaseFilter]):
     """Async resource for accessing concepts endpoints."""
 
-    endpoint = "concepts"
+    endpoint = Resource.CONCEPTS.value
     model_class = Concept
     filter_class = BaseFilter
 

--- a/openalex/resources/funders.py
+++ b/openalex/resources/funders.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import ROR_URL_PREFIX, Resource
 from ..models import BaseFilter, Funder
 from ..utils import ensure_prefix
 from .base import AsyncBaseResource, BaseResource
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class FundersResource(BaseResource[Funder, BaseFilter]):
     """Resource for accessing funders endpoints."""
 
-    endpoint = "funders"
+    endpoint = Resource.FUNDERS.value
     model_class = Funder
     filter_class = BaseFilter
 
@@ -34,13 +35,13 @@ class FundersResource(BaseResource[Funder, BaseFilter]):
         Returns:
             Funder instance
         """
-        return self.get(ensure_prefix(ror, "https://ror.org/"))
+        return self.get(ensure_prefix(ror, ROR_URL_PREFIX))
 
 
 class AsyncFundersResource(AsyncBaseResource[Funder, BaseFilter]):
     """Async resource for accessing funders endpoints."""
 
-    endpoint = "funders"
+    endpoint = Resource.FUNDERS.value
     model_class = Funder
     filter_class = BaseFilter
 
@@ -57,4 +58,4 @@ class AsyncFundersResource(AsyncBaseResource[Funder, BaseFilter]):
         Returns:
             Funder instance
         """
-        return await self.get(ensure_prefix(ror, "https://ror.org/"))
+        return await self.get(ensure_prefix(ror, ROR_URL_PREFIX))

--- a/openalex/resources/institutions.py
+++ b/openalex/resources/institutions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import ROR_URL_PREFIX, Resource
 from ..models import Institution, InstitutionsFilter
 from ..utils import ensure_prefix
 from .base import AsyncBaseResource, BaseResource
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class InstitutionsResource(BaseResource[Institution, InstitutionsFilter]):
     """Resource for accessing institutions endpoints."""
 
-    endpoint = "institutions"
+    endpoint = Resource.INSTITUTIONS.value
     model_class = Institution
     filter_class = InstitutionsFilter
 
@@ -34,7 +35,7 @@ class InstitutionsResource(BaseResource[Institution, InstitutionsFilter]):
         Returns:
             Institution instance
         """
-        return self.get(ensure_prefix(ror, "https://ror.org/"))
+        return self.get(ensure_prefix(ror, ROR_URL_PREFIX))
 
 
 class AsyncInstitutionsResource(
@@ -42,7 +43,7 @@ class AsyncInstitutionsResource(
 ):
     """Async resource for accessing institutions endpoints."""
 
-    endpoint = "institutions"
+    endpoint = Resource.INSTITUTIONS.value
     model_class = Institution
     filter_class = InstitutionsFilter
 
@@ -59,4 +60,4 @@ class AsyncInstitutionsResource(
         Returns:
             Institution instance
         """
-        return await self.get(ensure_prefix(ror, "https://ror.org/"))
+        return await self.get(ensure_prefix(ror, ROR_URL_PREFIX))

--- a/openalex/resources/keywords.py
+++ b/openalex/resources/keywords.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import Resource
 from ..models import BaseFilter, Keyword
 from .base import AsyncBaseResource, BaseResource
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 class KeywordsResource(BaseResource[Keyword, BaseFilter]):
     """Resource for accessing keywords endpoints."""
 
-    endpoint = "keywords"
+    endpoint = Resource.KEYWORDS.value
     model_class = Keyword
     filter_class = BaseFilter
 
@@ -28,7 +29,7 @@ class KeywordsResource(BaseResource[Keyword, BaseFilter]):
 class AsyncKeywordsResource(AsyncBaseResource[Keyword, BaseFilter]):
     """Async resource for accessing keywords endpoints."""
 
-    endpoint = "keywords"
+    endpoint = Resource.KEYWORDS.value
     model_class = Keyword
     filter_class = BaseFilter
 

--- a/openalex/resources/publishers.py
+++ b/openalex/resources/publishers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import Resource
 from ..models import BaseFilter, Publisher
 from .base import AsyncBaseResource, BaseResource
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 class PublishersResource(BaseResource[Publisher, BaseFilter]):
     """Resource for accessing publishers endpoints."""
 
-    endpoint = "publishers"
+    endpoint = Resource.PUBLISHERS.value
     model_class = Publisher
     filter_class = BaseFilter
 
@@ -28,7 +29,7 @@ class PublishersResource(BaseResource[Publisher, BaseFilter]):
 class AsyncPublishersResource(AsyncBaseResource[Publisher, BaseFilter]):
     """Async resource for accessing publishers endpoints."""
 
-    endpoint = "publishers"
+    endpoint = Resource.PUBLISHERS.value
     model_class = Publisher
     filter_class = BaseFilter
 

--- a/openalex/resources/sources.py
+++ b/openalex/resources/sources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import Resource
 from ..models import BaseFilter, Source
 from .base import AsyncBaseResource, BaseResource
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 class SourcesResource(BaseResource[Source, BaseFilter]):
     """Resource for accessing sources endpoints."""
 
-    endpoint = "sources"
+    endpoint = Resource.SOURCES.value
     model_class = Source
     filter_class = BaseFilter
 
@@ -43,7 +44,7 @@ class SourcesResource(BaseResource[Source, BaseFilter]):
 class AsyncSourcesResource(AsyncBaseResource[Source, BaseFilter]):
     """Async resource for accessing sources endpoints."""
 
-    endpoint = "sources"
+    endpoint = Resource.SOURCES.value
     model_class = Source
     filter_class = BaseFilter
 

--- a/openalex/resources/topics.py
+++ b/openalex/resources/topics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..constants import Resource
 from ..models import BaseFilter, Topic
 from .base import AsyncBaseResource, BaseResource
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 class TopicsResource(BaseResource[Topic, BaseFilter]):
     """Resource for accessing topics endpoints."""
 
-    endpoint = "topics"
+    endpoint = Resource.TOPICS.value
     model_class = Topic
     filter_class = BaseFilter
 
@@ -28,7 +29,7 @@ class TopicsResource(BaseResource[Topic, BaseFilter]):
 class AsyncTopicsResource(AsyncBaseResource[Topic, BaseFilter]):
     """Async resource for accessing topics endpoints."""
 
-    endpoint = "topics"
+    endpoint = Resource.TOPICS.value
     model_class = Topic
     filter_class = BaseFilter
 

--- a/openalex/resources/works.py
+++ b/openalex/resources/works.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
-from ..constants import DOI_URL_PREFIX, PMID_PREFIX
+from ..constants import DOI_URL_PREFIX, PMID_PREFIX, Resource
 from ..models import ListResult, Work, WorksFilter
 from ..utils import ensure_prefix, strip_id_prefix
 from ..utils.pagination import MAX_PER_PAGE
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class WorksResource(BaseResource[Work, WorksFilter]):
     """Resource for accessing works endpoints."""
 
-    endpoint = "works"
+    endpoint = Resource.WORKS.value
     model_class = Work
     filter_class = WorksFilter
 
@@ -210,7 +210,7 @@ class WorksResource(BaseResource[Work, WorksFilter]):
 class AsyncWorksResource(AsyncBaseResource[Work, WorksFilter]):
     """Async resource for accessing works endpoints."""
 
-    endpoint = "works"
+    endpoint = Resource.WORKS.value
     model_class = Work
     filter_class = WorksFilter
 

--- a/openalex/utils/pagination.py
+++ b/openalex/utils/pagination.py
@@ -10,9 +10,11 @@ from structlog import get_logger
 from ..constants import (
     DEFAULT_CONCURRENCY,
     DEFAULT_PER_PAGE,
+    FIRST_PAGE,
     PARAM_CURSOR,
     PARAM_PAGE,
     PARAM_PER_PAGE,
+    SINGLE_PER_PAGE,
 )
 
 __all__ = [
@@ -68,7 +70,7 @@ class Paginator(Generic[T]):
 
     def __iter__(self) -> Iterator[T]:
         """Iterate over all results."""
-        page: int | None = 1
+        page: int | None = FIRST_PAGE
         cursor = self.params.get(PARAM_CURSOR)
         base_params = {
             k: v for k, v in self.params.items() if k != PARAM_CURSOR
@@ -121,7 +123,7 @@ class Paginator(Generic[T]):
 
     def pages(self) -> Iterator[ListResult[T]]:
         """Iterate over pages instead of individual results."""
-        page: int | None = 1
+        page: int | None = FIRST_PAGE
         cursor = self.params.get(PARAM_CURSOR)
         base_params = {
             k: v for k, v in self.params.items() if k != PARAM_CURSOR
@@ -174,8 +176,8 @@ class Paginator(Generic[T]):
     def count(self) -> int:
         """Get total count without fetching all results."""
         params = self.params.copy()
-        params[PARAM_PER_PAGE] = 1
-        params[PARAM_PAGE] = 1
+        params[PARAM_PER_PAGE] = SINGLE_PER_PAGE
+        params[PARAM_PAGE] = FIRST_PAGE
 
         result = self.fetch_func(params)
         return result.meta.count
@@ -210,7 +212,7 @@ class AsyncPaginator(Generic[T]):
 
     async def __aiter__(self) -> AsyncIterator[T]:
         """Iterate over all results asynchronously."""
-        page: int | None = 1
+        page: int | None = FIRST_PAGE
         cursor = self.params.get(PARAM_CURSOR)
         base_params = {
             k: v for k, v in self.params.items() if k != PARAM_CURSOR
@@ -262,7 +264,7 @@ class AsyncPaginator(Generic[T]):
 
     async def pages(self) -> AsyncIterator[ListResult[T]]:
         """Iterate over pages instead of individual results."""
-        page: int | None = 1
+        page: int | None = FIRST_PAGE
         cursor = self.params.get(PARAM_CURSOR)
         base_params = {
             k: v for k, v in self.params.items() if k != PARAM_CURSOR
@@ -317,8 +319,8 @@ class AsyncPaginator(Generic[T]):
     async def count(self) -> int:
         """Get total count without fetching all results."""
         params = self.params.copy()
-        params[PARAM_PER_PAGE] = 1
-        params[PARAM_PAGE] = 1
+        params[PARAM_PER_PAGE] = SINGLE_PER_PAGE
+        params[PARAM_PAGE] = FIRST_PAGE
 
         result: ListResult[T] = await self.fetch_func(params)
         return result.meta.count


### PR DESCRIPTION
## Summary
- centralize hard coded strings and numbers into constants
- use new `Resource` enum instead of magic endpoint names
- apply new constants across config and pagination logic
- tidy mypy and ruff formatting

## Testing
- `ruff format .`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472f2bf7d0832bac43055780b42a19