### PR TITLE
Repo maintenance and lint fixes

### DIFF
--- a/openalex/models/author.py
+++ b/openalex/models/author.py
@@ -147,6 +147,6 @@ class Author(OpenAlexEntity):
         return [c.display_name for c in self.x_concepts if c.display_name]
 
 
-from .work import DehydratedConcept, DehydratedInstitution  # noqa: E402,TC001
+from .work import DehydratedConcept, DehydratedInstitution  # noqa: E402,TCH001
 
 Author.model_rebuild()

--- a/openalex/models/funder.py
+++ b/openalex/models/funder.py
@@ -85,7 +85,7 @@ class Funder(OpenAlexEntity):
                 try:
                     date_part, time_part = v.split("T")
                     time_str, *rest = time_part.split(".")
-                    hour, minute, second = [int(x) for x in time_str.split(":")]
+                    hour, minute, second = (int(x) for x in time_str.split(":"))
                     minute += second // SECONDS_PER_MINUTE
                     second %= SECONDS_PER_MINUTE
                     hour += minute // MINUTES_PER_HOUR

--- a/openalex/models/institution.py
+++ b/openalex/models/institution.py
@@ -26,9 +26,9 @@ from .base import (
     Role,
     SummaryStats,
 )
-from .topic import TopicHierarchy  # noqa: TC001
 
 if TYPE_CHECKING:
+    from .topic import TopicHierarchy
     from .work import DehydratedConcept
 
 
@@ -278,6 +278,7 @@ class Institution(OpenAlexEntity):
         )
 
 
-from .work import DehydratedConcept  # noqa: E402,TC001
+from .topic import TopicHierarchy  # noqa: E402,TCH001
+from .work import DehydratedConcept  # noqa: E402,TCH001
 
 Institution.model_rebuild()

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -209,6 +209,6 @@ class Source(OpenAlexEntity):
         )
 
 
-from .work import DehydratedConcept  # noqa: E402,TC001
+from .work import DehydratedConcept  # noqa: E402,TCH001
 
 Source.model_rebuild()

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import IntEnum
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 __all__ = ["Topic", "TopicHierarchy", "TopicIds", "TopicLevel"]
 
@@ -18,6 +18,9 @@ from pydantic import (
 )
 
 from ..constants import MAX_SECONDS_IN_MINUTE
+
+if TYPE_CHECKING:
+    from .work import DehydratedTopic
 from .base import OpenAlexBase, OpenAlexEntity, SummaryStats
 
 MALFORMED_DATETIME_REGEX = re.compile(
@@ -160,6 +163,6 @@ class Topic(OpenAlexEntity):
         }
 
 
-from .work import DehydratedTopic  # noqa: E402,TC001
+from .work import DehydratedTopic  # noqa: E402,TCH001
 
 Topic.model_rebuild()

--- a/openalex/models/work.py
+++ b/openalex/models/work.py
@@ -500,8 +500,8 @@ class InstitutionsFilter(BaseFilter):
         return self.model_copy(update={"filter": current_filter})
 
 
-from .institution import InstitutionType  # noqa: E402,TC001
-from .topic import TopicHierarchy  # noqa: E402,TC001
+from .institution import InstitutionType  # noqa: E402,TCH001
+from .topic import TopicHierarchy  # noqa: E402,TCH001
 
 DehydratedTopic.model_rebuild()
 DehydratedInstitution.model_rebuild()

--- a/openalex/utils/retry.py
+++ b/openalex/utils/retry.py
@@ -117,7 +117,8 @@ def with_retry(
                     return func(*args, **kwargs)
         except RetryError as e:
             if e.last_attempt.failed:
-                raise e.last_attempt.result() from e
+                exc = e.last_attempt.result()
+                raise exc from e
             raise
 
         raise AssertionError(UNREACHABLE_MSG)
@@ -162,7 +163,8 @@ def async_with_retry(
                     return await func(*args, **kwargs)
         except RetryError as e:
             if e.last_attempt.failed:
-                raise e.last_attempt.result() from e
+                exc = e.last_attempt.result()
+                raise exc from e
             raise
 
         raise AssertionError(UNREACHABLE_MSG)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 
-@pytest.fixture
+@pytest.fixture()
 def config() -> OpenAlexConfig:
     """Create test configuration."""
     return OpenAlexConfig(
@@ -25,7 +25,7 @@ def config() -> OpenAlexConfig:
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def client(config: OpenAlexConfig) -> Generator[OpenAlex, None, None]:
     """Create test client."""
     c = OpenAlex(config=config)
@@ -33,7 +33,7 @@ def client(config: OpenAlexConfig) -> Generator[OpenAlex, None, None]:
     c.close()
 
 
-@pytest.fixture
+@pytest.fixture()
 async def async_client(config: OpenAlexConfig) -> AsyncOpenAlex:
     """Create async test client."""
     c = AsyncOpenAlex(config=config)
@@ -41,7 +41,7 @@ async def async_client(config: OpenAlexConfig) -> AsyncOpenAlex:
     await c.close()
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_work_response() -> dict[str, Any]:
     """Mock work API response."""
     return {
@@ -94,7 +94,7 @@ def mock_work_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_author_response() -> dict[str, Any]:
     """Mock author API response."""
     return {
@@ -134,7 +134,7 @@ def mock_author_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_list_response(mock_work_response: dict[str, Any]) -> dict[str, Any]:
     """Mock list API response."""
     return {
@@ -149,7 +149,7 @@ def mock_list_response(mock_work_response: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_autocomplete_response() -> dict[str, Any]:
     """Mock autocomplete API response."""
     return {
@@ -178,7 +178,7 @@ def mock_autocomplete_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_error_response() -> dict[str, Any]:
     """Mock error API response."""
     return {

--- a/tests/models/test_author.py
+++ b/tests/models/test_author.py
@@ -14,7 +14,7 @@ from openalex.models import (
 class TestAuthor:
     """Test Author model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_author_data(self) -> dict[str, Any]:
         """Comprehensive author data based on real OpenAlex API response."""
         return {
@@ -126,7 +126,7 @@ class TestAuthor:
             "updated_date": "2024-12-16T09:27:51.699330",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def minimal_author_data(self) -> dict[str, Any]:
         """Minimal author data for edge case testing."""
         return {
@@ -136,7 +136,7 @@ class TestAuthor:
             "cited_by_count": 0,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def author_with_multiple_affiliations_data(self) -> dict[str, Any]:
         """Author with complex affiliation history."""
         return {

--- a/tests/models/test_concept.py
+++ b/tests/models/test_concept.py
@@ -15,7 +15,7 @@ from openalex.models import (
 class TestConcept:
     """Test Concept model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_concept_data(self) -> dict[str, Any]:
         """Comprehensive concept data based on real OpenAlex API response."""
         return {
@@ -139,7 +139,7 @@ class TestConcept:
             "updated_date": "2024-12-16T11:23:45.678901",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def hierarchical_concept_data(self) -> dict[str, Any]:
         """Concept with complex hierarchy."""
         return {
@@ -183,7 +183,7 @@ class TestConcept:
             ],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def deep_hierarchy_concept_data(self) -> dict[str, Any]:
         """Concept at level 5 with full ancestry."""
         return {

--- a/tests/models/test_funder.py
+++ b/tests/models/test_funder.py
@@ -12,7 +12,7 @@ from openalex.models import CountsByYear, Funder
 class TestFunder:
     """Test Funder model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def government_funder_data(self) -> dict[str, Any]:
         """Government funder data based on real OpenAlex API response."""
         return {
@@ -66,7 +66,7 @@ class TestFunder:
             "updated_date": "2024-12-16T13:45:67.890123",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def private_foundation_data(self) -> dict[str, Any]:
         """Private foundation funder data."""
         return {
@@ -102,7 +102,7 @@ class TestFunder:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def european_funder_data(self) -> dict[str, Any]:
         """European research council funder data."""
         return {

--- a/tests/models/test_institution.py
+++ b/tests/models/test_institution.py
@@ -15,7 +15,7 @@ from openalex.models import (
 class TestInstitution:
     """Test Institution model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_institution_data(self) -> dict[str, Any]:
         """Comprehensive institution data based on real OpenAlex API response."""
         return {
@@ -231,7 +231,7 @@ class TestInstitution:
             "updated_date": "2024-12-16T09:53:16.081181",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def company_institution_data(self) -> dict[str, Any]:
         """Company institution data."""
         return {
@@ -269,7 +269,7 @@ class TestInstitution:
             "repositories": [],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def hierarchical_institution_data(self) -> dict[str, Any]:
         """Institution with complex hierarchy."""
         return {

--- a/tests/models/test_keyword.py
+++ b/tests/models/test_keyword.py
@@ -11,7 +11,7 @@ from openalex.models import Keyword
 class TestKeyword:
     """Test Keyword model with comprehensive fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_keyword_data(self) -> dict[str, Any]:
         """Comprehensive keyword data based on real OpenAlex API response."""
         return {
@@ -22,7 +22,7 @@ class TestKeyword:
             "cited_by_count": 12345678,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def popular_keyword_data(self) -> dict[str, Any]:
         """Popular keyword with high metrics."""
         return {
@@ -33,7 +33,7 @@ class TestKeyword:
             "cited_by_count": 34567890,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def new_keyword_data(self) -> dict[str, Any]:
         """New keyword with low metrics."""
         return {

--- a/tests/models/test_publisher.py
+++ b/tests/models/test_publisher.py
@@ -12,7 +12,7 @@ from openalex.models import Publisher
 class TestPublisher:
     """Test Publisher model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def parent_publisher_data(self) -> dict[str, Any]:
         """Parent publisher data based on real OpenAlex API response."""
         return {
@@ -72,7 +72,7 @@ class TestPublisher:
             "updated_date": "2024-12-16T12:34:56.789012",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def child_publisher_data(self) -> dict[str, Any]:
         """Child publisher data (imprint)."""
         return {
@@ -117,7 +117,7 @@ class TestPublisher:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def university_press_publisher_data(self) -> dict[str, Any]:
         """University press publisher data."""
         return {

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -17,7 +17,7 @@ from openalex.models import (
 class TestSource:
     """Test Source model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def journal_source_data(self) -> dict[str, Any]:
         """Comprehensive journal source data based on real OpenAlex API response."""
         return {
@@ -100,7 +100,7 @@ class TestSource:
             "updated_date": "2024-12-16T10:12:34.567890",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def repository_source_data(self) -> dict[str, Any]:
         """Repository source data."""
         return {
@@ -146,7 +146,7 @@ class TestSource:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def conference_source_data(self) -> dict[str, Any]:
         """Conference source data."""
         return {
@@ -177,7 +177,7 @@ class TestSource:
             ],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def ebook_platform_source_data(self) -> dict[str, Any]:
         """E-book platform source data."""
         return {

--- a/tests/models/test_topic.py
+++ b/tests/models/test_topic.py
@@ -17,7 +17,7 @@ from openalex.models import (
 class TestTopic:
     """Test Topic model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def domain_topic_data(self) -> dict[str, Any]:
         """Domain-level topic data (level 0)."""
         return {
@@ -60,7 +60,7 @@ class TestTopic:
             "updated_date": "2024-12-16T14:56:78.901234",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def field_topic_data(self) -> dict[str, Any]:
         """Field-level topic data (level 1)."""
         return {
@@ -101,7 +101,7 @@ class TestTopic:
             "cited_by_count": 67890123,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def subfield_topic_data(self) -> dict[str, Any]:
         """Subfield-level topic data (level 2) - most detailed level."""
         return {
@@ -152,7 +152,7 @@ class TestTopic:
             "updated_date": "2024-12-16T15:12:34.567890",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def interdisciplinary_topic_data(self) -> dict[str, Any]:
         """Interdisciplinary topic spanning multiple domains."""
         return {

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -27,7 +27,7 @@ from openalex.models.work import (
 class TestWork:
     """Test Work model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_work_data(self) -> dict[str, Any]:
         """Comprehensive work data based on real OpenAlex API response."""
         return {

--- a/tests/resources/base.py
+++ b/tests/resources/base.py
@@ -392,7 +392,7 @@ class BaseResourceTest(Generic[T]):
 
         assert exc_info.value.status_code == 500
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_get(
         self,
         async_client: AsyncOpenAlex,
@@ -410,7 +410,7 @@ class BaseResourceTest(Generic[T]):
 
         assert isinstance(entity, self.entity_class)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_pagination(
         self,
         async_client: AsyncOpenAlex,
@@ -432,7 +432,7 @@ class BaseResourceTest(Generic[T]):
 
         assert len(results) == 10
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_random(
         self, async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
     ) -> None:
@@ -445,7 +445,7 @@ class BaseResourceTest(Generic[T]):
         entity = await resource.random()
         assert isinstance(entity, self.entity_class)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_autocomplete(
         self, async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
     ) -> None:
@@ -475,7 +475,7 @@ class BaseResourceTest(Generic[T]):
         assert result.meta.count == 3
         assert len(result.results) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_get_with_full_url(
         self,
         async_client: AsyncOpenAlex,

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def sample_filters() -> dict[str, Any]:
     """Common filter scenarios for testing."""
     return {
@@ -27,7 +27,7 @@ def sample_filters() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def error_scenarios() -> dict[str, dict[str, Any]]:
     """Common error scenarios for testing."""
     return {
@@ -41,7 +41,7 @@ def error_scenarios() -> dict[str, dict[str, Any]]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def pagination_scenarios() -> dict[str, dict[str, Any]]:
     """Pagination test scenarios."""
     return {

--- a/tests/resources/test_authors.py
+++ b/tests/resources/test_authors.py
@@ -323,7 +323,7 @@ class TestAuthorsResource(BaseResourceTest[Author]):
         )
         assert result.meta.count == 1000
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_by_mag(
         self, async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
     ) -> None:
@@ -336,7 +336,7 @@ class TestAuthorsResource(BaseResourceTest[Author]):
         author = await async_client.authors.by_mag(mag_id)
         assert author.id == entity_data["id"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_by_orcid(
         self, async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
     ) -> None:
@@ -365,7 +365,7 @@ class TestAuthorsResource(BaseResourceTest[Author]):
         result = resource.by_institution("I123").list()
         assert result.meta.count == 100
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_clone_with_raw_filter(
         self,
         async_client: AsyncOpenAlex,
@@ -389,7 +389,7 @@ def test_filter_builder_authors(client: OpenAlex) -> None:
     assert filt.page == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_filter_builder_authors(
     async_client: AsyncOpenAlex,
 ) -> None:
@@ -424,7 +424,7 @@ def test_default_filter_usage(
     assert len(paginator.all()) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_default_filter_usage(
     async_client: AsyncOpenAlex,
     httpx_mock: HTTPXMock,

--- a/tests/resources/test_concepts.py
+++ b/tests/resources/test_concepts.py
@@ -19,7 +19,7 @@ def test_by_wikidata_formats(client, httpx_mock):
     assert concept.id == "https://openalex.org/C456"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_by_wikidata(async_client, httpx_mock):
     httpx_mock.add_response(
         url="https://api.openalex.org/concepts/https://www.wikidata.org/entity/Q789?mailto=test%40example.com",

--- a/tests/resources/test_sources.py
+++ b/tests/resources/test_sources.py
@@ -283,7 +283,7 @@ class TestSourcesResource(BaseResourceTest[Source]):
         )
         assert sources_with_homepage.meta.count == 8000
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_by_issn(
         self,
         async_client: AsyncOpenAlex,

--- a/tests/resources/test_works.py
+++ b/tests/resources/test_works.py
@@ -517,7 +517,7 @@ def test_clone_with_merges_default_filter(client: OpenAlex) -> None:
     assert new_res._default_filter.filter["authorships.author.id"] == "A123"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_by_doi(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -531,7 +531,7 @@ async def test_async_by_doi(
     assert work.id == entity_data["id"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_by_pmid(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -545,7 +545,7 @@ async def test_async_by_pmid(
     assert work.id == entity_data["id"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_open_access_list(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -559,7 +559,7 @@ async def test_async_open_access_list(
     assert result.meta.count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_work_helpers(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -609,7 +609,7 @@ async def test_async_work_helpers(
     ).meta.count == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_search_with_default_filter(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -629,7 +629,7 @@ def test_parse_list_response_error(client: OpenAlex) -> None:
         resource._parse_list_response(bad_data)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_apply_filter_params(
     async_client: AsyncOpenAlex, httpx_mock: HTTPXMock
 ) -> None:
@@ -642,7 +642,7 @@ async def test_async_apply_filter_params(
     assert result.meta.count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_parse_list_response_error(
     async_client: AsyncOpenAlex,
 ) -> None:
@@ -652,7 +652,7 @@ async def test_async_parse_list_response_error(
         resource._parse_list_response(bad_data)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_filter_builder(async_client: AsyncOpenAlex) -> None:
     filt = async_client.works.filter(page=3)
     assert isinstance(filt, WorksFilter)
@@ -685,7 +685,7 @@ def test_paginate_default_filter_usage(
     assert len(paginator.all()) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_clone_with_string_filter(
     async_client: AsyncOpenAlex,
 ) -> None:
@@ -698,7 +698,7 @@ async def test_async_clone_with_string_filter(
     assert new_res._default_filter.filter["authorships.author.id"] == "A123"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginate_default_filter(
     async_client: AsyncOpenAlex,
     httpx_mock: HTTPXMock,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,7 +169,7 @@ class TestOpenAlexClient:
 class TestAsyncOpenAlexClient:
     """Test asynchronous OpenAlex client."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_initialization(self) -> None:
         """Test async client initialization."""
         client = AsyncOpenAlex(email="test@example.com")
@@ -178,13 +178,13 @@ class TestAsyncOpenAlexClient:
         assert client.authors is not None
         await client.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_context_manager(self) -> None:
         """Test async client as context manager."""
         async with AsyncOpenAlex(email="test@example.com") as client:
             assert client.config.email == "test@example.com"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_autocomplete(
         self,
         httpx_mock: HTTPXMock,
@@ -201,7 +201,7 @@ class TestAsyncOpenAlexClient:
             assert len(results.results) == 2
             assert results.results[0].entity_type == "work"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_text_aboutness(
         self,
         httpx_mock: HTTPXMock,
@@ -215,7 +215,7 @@ class TestAsyncOpenAlexClient:
             result = await client.text_aboutness(title="bar")
             assert result["meta"]["title"] == "bar"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_search_all(
         self,
         httpx_mock: HTTPXMock,
@@ -268,7 +268,7 @@ class TestClientHelpers:
                 work.title == "Generalized Gradient Approximation Made Simple"
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_async_client_helper(
         self,
         httpx_mock: HTTPXMock,
@@ -289,7 +289,7 @@ class TestClientHelpers:
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_client_api_key_override(config: OpenAlexConfig) -> None:
     client = AsyncOpenAlex(config=config, api_key="abc")
     try:
@@ -382,7 +382,7 @@ def test_search_all_error(
     assert res["works"].meta.count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_retry(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -413,7 +413,7 @@ async def test_async_request_retry(
     await client.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_autocomplete_entity(
     httpx_mock: HTTPXMock,
     config: OpenAlexConfig,
@@ -428,7 +428,7 @@ async def test_async_autocomplete_entity(
         assert len(res.results) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_search_all_error(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -496,7 +496,7 @@ def test_request_all_fail(
     assert calls["attempts"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_text_aboutness_with_abstract_and_type(
     httpx_mock: HTTPXMock, config: OpenAlexConfig
 ) -> None:
@@ -512,7 +512,7 @@ async def test_async_text_aboutness_with_abstract_and_type(
         assert result["meta"]["title"] == "foo"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_all_fail(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -553,7 +553,7 @@ def test_request_zero_attempts(config: OpenAlexConfig) -> None:
         client._request("GET", "https://api.openalex.org/test")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_sleep(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -580,7 +580,7 @@ async def test_async_request_sleep(
     await client.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_timeout(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -605,7 +605,7 @@ async def test_async_request_timeout(
     await client.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_generic_error(
     monkeypatch: pytest.MonkeyPatch, config: OpenAlexConfig
 ) -> None:
@@ -630,7 +630,7 @@ async def test_async_request_generic_error(
     await client.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_request_no_attempts(config: OpenAlexConfig) -> None:
     """Async client should raise NetworkError when attempts are zero."""
     client = AsyncOpenAlex(

--- a/tests/utils/test_pagination.py
+++ b/tests/utils/test_pagination.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from builtins import anext
 from typing import Any
 
 import pytest
@@ -46,7 +47,7 @@ def test_paginator_iteration() -> None:
     assert paginator.count() == total
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather() -> None:
     total = 5
 
@@ -92,7 +93,7 @@ def test_paginator_error() -> None:
         list(paginator)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_first_all() -> None:
     total = 5
 
@@ -113,7 +114,7 @@ async def test_async_paginator_pages_first_all() -> None:
     assert len(results) == total
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_error() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         msg = "bad"
@@ -129,7 +130,7 @@ async def test_async_paginator_error() -> None:
         await iterate_paginator()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather_max_results() -> None:
     total = 10
 
@@ -161,7 +162,7 @@ def test_paginator_pages_error() -> None:
         next(paginator.pages())
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_error() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         msg = "boom"
@@ -169,8 +170,7 @@ async def test_async_paginator_pages_error() -> None:
 
     paginator = AsyncPaginator(fetch)
     with pytest.raises(APIError):
-        async for _ in paginator.pages():
-            pass
+        await anext(paginator.pages())
 
 
 def test_paginator_first_no_results() -> None:
@@ -185,7 +185,7 @@ def test_paginator_first_no_results() -> None:
     assert paginator.count() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_first_no_results() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         meta = Meta(
@@ -198,7 +198,7 @@ async def test_async_paginator_first_no_results() -> None:
     assert await paginator.count() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_max_results_iter() -> None:
     total = 5
 
@@ -231,7 +231,7 @@ def test_paginator_page_increment_and_all() -> None:
     assert [w.id for w in items] == ["W0", "W1", "W2", "W3", "W4"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_page_increment() -> None:
     """Async paginator uses page numbers when no cursor is returned."""
     total = 5
@@ -249,7 +249,7 @@ async def test_async_paginator_pages_page_increment() -> None:
     assert len(pages) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather_respects_max_results() -> None:
     """gather stops when reaching ``max_results``."""
     total = 10

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -22,7 +22,7 @@ def test_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not limiter.try_acquire()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limiter() -> None:
     limiter = AsyncRateLimiter(rate=1, burst=1, buffer=0)
     assert await limiter.acquire() == 0
@@ -48,7 +48,7 @@ def test_rate_limited_decorator(monkeypatch: pytest.MonkeyPatch) -> None:
     assert calls[0] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limited_decorator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -106,7 +106,7 @@ def test_sliding_window_rate_limiter_clean(
     assert wait_after == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limiter_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -31,7 +31,7 @@ def test_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     attempts: list[int] = []
 
@@ -68,7 +68,7 @@ def test_retry_config_wait_strategy() -> None:
     assert isinstance(strategy, type(wait_exponential()))
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_retry_handler_should_retry_and_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -110,7 +110,7 @@ def test_with_retry_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -149,7 +149,7 @@ def test_with_retry_default_config(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry_default_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- clean up runtime imports for pydantic models
- tweak retry helper to avoid unnecessary parentheses
- modernise paginator tests to use `anext`
- run ruff, mypy and tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ebfc0a0c832b92176d924966ac8e