### PR TITLE
feat: enhance Query class with PyAlex-style fluent interface (Phase 1)

### DIFF
--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -129,6 +129,7 @@ from .models import (  # noqa: E402
     WorksFilter,
     WorkType,
 )
+from .query import Query, gt_, lt_, not_, or_  # noqa: E402
 from .utils import (  # noqa: E402
     AsyncPaginator,
     AsyncRateLimiter,
@@ -144,7 +145,7 @@ from .utils import (  # noqa: E402
     with_retry,
 )
 
-__all__ = [
+__all__ = [  # noqa: RUF022
     "APC",
     "APCPrice",
     "APIError",
@@ -200,6 +201,11 @@ __all__ = [
     "NotFoundError",
     "OpenAccess",
     "OpenAccessStatus",
+    "Query",
+    "or_",
+    "not_",
+    "gt_",
+    "lt_",
     # Client classes
     "OpenAlex",
     # Base models

--- a/openalex/query.py
+++ b/openalex/query.py
@@ -14,6 +14,40 @@ T = TypeVar("T")
 F = TypeVar("F", bound=BaseFilter)
 
 
+class or_(dict[str, Any]):  # noqa: N801
+    """Logical OR expression for filters."""
+
+
+class _LogicalExpression:
+    """Base class for logical expressions."""
+
+    token: str = ""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        return f"{self.token}{self.value}"
+
+
+class not_(_LogicalExpression):  # noqa: N801
+    """Logical NOT expression."""
+
+    token = "!"
+
+
+class gt_(_LogicalExpression):  # noqa: N801
+    """Greater than expression."""
+
+    token = ">"
+
+
+class lt_(_LogicalExpression):  # noqa: N801
+    """Less than expression."""
+
+    token = "<"
+
+
 class Query(Generic[T, F]):
     """Fluent interface for building API queries."""
 
@@ -25,13 +59,25 @@ class Query(Generic[T, F]):
         self.resource = resource
         self.params: dict[str, Any] = params or {}
 
+    def __getitem__(self, record_id: str | list[str]) -> T | ListResult[T]:
+        """Get entity by ID or list of IDs."""
+        if isinstance(record_id, list):
+            return self.filter(openalex_id=record_id).get(
+                per_page=len(record_id)
+            )
+        return self.resource.get(record_id)
+
     # internal helper
     def _clone(self, **updates: Any) -> Query[T, F]:
         new_params = {**self.params}
         for key, value in updates.items():
             if key == "filter" and value is not None:
                 current = new_params.get("filter", {})
-                if isinstance(current, dict) and isinstance(value, dict):
+                if (
+                    isinstance(current, dict)
+                    and isinstance(value, dict)
+                    and not isinstance(value, or_)
+                ):
                     current.update(value)
                     new_params[key] = current
                 else:
@@ -39,6 +85,25 @@ class Query(Generic[T, F]):
             else:
                 new_params[key] = value
         return Query(self.resource, new_params)
+
+    def _merge_filter_dict(
+        self,
+        current: dict[str, Any],
+        new: dict[str, Any],
+        operation: str = "and",
+    ) -> dict[str, Any]:
+        """Merge filter dictionaries based on operation type."""
+        if operation == "or":
+            return or_({**current, **new})
+        result = current.copy()
+        result.update(new)
+        return result
+
+    def _apply_logical_operation(
+        self, filter_dict: dict[str, Any], operation: type[_LogicalExpression]
+    ) -> dict[str, Any]:
+        """Apply a logical operation to all values in a filter dict."""
+        return {k: operation(v) for k, v in filter_dict.items()}
 
     # --- builder methods -------------------------------------------------
     def filter(self, **kwargs: Any) -> Query[T, F]:
@@ -69,11 +134,44 @@ class Query(Generic[T, F]):
             params["seed"] = seed
         return self._clone(**params)
 
+    def filter_or(self, **kwargs: Any) -> Query[T, F]:
+        """Add OR filter parameters."""
+        current = self.params.get("filter", {})
+        if isinstance(current, dict):
+            new_filter = self._merge_filter_dict(current, kwargs, "or")
+            return self._clone(filter=new_filter)
+        return self._clone(filter=or_(kwargs))
+
+    def filter_not(self, **kwargs: Any) -> Query[T, F]:
+        """Add NOT filter parameters."""
+        not_filters = self._apply_logical_operation(kwargs, not_)
+        return self.filter(**not_filters)
+
+    def filter_gt(self, **kwargs: Any) -> Query[T, F]:
+        """Add greater than filter parameters."""
+        gt_filters = self._apply_logical_operation(kwargs, gt_)
+        return self.filter(**gt_filters)
+
+    def filter_lt(self, **kwargs: Any) -> Query[T, F]:
+        """Add less than filter parameters."""
+        lt_filters = self._apply_logical_operation(kwargs, lt_)
+        return self.filter(**lt_filters)
+
+    def search_filter(self, **kwargs: Any) -> Query[T, F]:
+        """Add search filter parameters (search within specific fields)."""
+        search_filters = {f"{k}.search": v for k, v in kwargs.items()}
+        return self.filter(**search_filters)
+
     # --- execution methods -----------------------------------------------
-    def list(self, **kwargs: Any) -> ListResult[T]:
-        """Execute the query and return a list of results."""
+    def get(self, **kwargs: Any) -> ListResult[T]:
+        """Execute query and return results (alias for list())."""
         params = {**self.params, **kwargs}
-        return self.resource.list(filter=params.get("filter"), **params)
+        filter_param = params.pop("filter", None)
+        return self.resource.list(filter=filter_param, **params)
+
+    def list(self, **kwargs: Any) -> ListResult[T]:
+        """Alias for :meth:`get`."""
+        return self.get(**kwargs)
 
     def paginate(
         self,
@@ -83,14 +181,23 @@ class Query(Generic[T, F]):
     ) -> Paginator[T]:
         """Return a paginator for this query."""
         params = {**self.params, **kwargs}
+        filter_param = params.pop("filter", None)
         return self.resource.paginate(
-            filter=params.get("filter"),
+            filter=filter_param,
             per_page=per_page,
             max_results=max_results,
             **params,
         )
 
     def count(self) -> int:
-        """Return the total count for this query."""
-        result = self.list(per_page=1)
+        """Get count of results without fetching them."""
+        result = self.get(per_page=1)
         return result.meta.count
+
+    def random(self) -> T:
+        """Get a random entity."""
+        return self.resource.random()
+
+    def autocomplete(self, query: str, **kwargs: Any) -> ListResult[Any]:
+        """Autocomplete search."""
+        return self.resource.autocomplete(query, **kwargs)

--- a/tests/test_query_enhanced.py
+++ b/tests/test_query_enhanced.py
@@ -1,0 +1,118 @@
+from openalex.models import ListResult
+from openalex.query import Query, gt_, lt_, not_, or_
+
+
+class MockResource:
+    """Mock resource for testing."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, id):
+        self.calls.append(("get", id))
+        return {"id": id, "type": "mock"}
+
+    def list(self, filter=None, **params):
+        self.calls.append(("list", filter, params))
+        meta = {
+            "count": 42,
+            "db_response_time_ms": 1,
+            "page": 1,
+            "per_page": params.get("per_page", 25),
+        }
+        return ListResult(meta=meta, results=[])
+
+    def random(self, **params):
+        self.calls.append(("random", params))
+        return {"id": "random", "type": "mock"}
+
+    def autocomplete(self, query, **params):
+        self.calls.append(("autocomplete", query, params))
+        meta = {"count": 5, "db_response_time_ms": 1, "page": 1, "per_page": 25}
+        return ListResult(meta=meta, results=[])
+
+
+def test_getitem_single():
+    resource = MockResource()
+    query = Query(resource)
+
+    result = query["W123456"]
+    assert result["id"] == "W123456"
+    assert resource.calls[-1] == ("get", "W123456")
+
+
+def test_getitem_multiple():
+    resource = MockResource()
+    query = Query(resource)
+
+    query[["W123", "W456"]]
+    assert resource.calls[-1][0] == "list"
+    assert resource.calls[-1][1]["openalex_id"] == ["W123", "W456"]
+
+
+def test_filter_or():
+    resource = MockResource()
+    query = Query(resource).filter_or(type="article", is_oa=True)
+
+    assert isinstance(query.params["filter"], or_)
+    assert query.params["filter"]["type"] == "article"
+    assert query.params["filter"]["is_oa"] is True
+
+
+def test_filter_not():
+    resource = MockResource()
+    query = Query(resource).filter_not(type="dataset")
+
+    filter_value = query.params["filter"]["type"]
+    assert isinstance(filter_value, not_)
+    assert filter_value.value == "dataset"
+
+
+def test_filter_gt_lt():
+    resource = MockResource()
+    query = (
+        Query(resource)
+        .filter_gt(cited_by_count=100)
+        .filter_lt(publication_year=2020)
+    )
+
+    assert isinstance(query.params["filter"]["cited_by_count"], gt_)
+    assert query.params["filter"]["cited_by_count"].value == 100
+    assert isinstance(query.params["filter"]["publication_year"], lt_)
+    assert query.params["filter"]["publication_year"].value == 2020
+
+
+def test_search_filter():
+    resource = MockResource()
+    query = Query(resource).search_filter(title="quantum", abstract="physics")
+
+    assert query.params["filter"]["title.search"] == "quantum"
+    assert query.params["filter"]["abstract.search"] == "physics"
+
+
+def test_count():
+    resource = MockResource()
+    query = Query(resource).filter(type="article")
+
+    count = query.count()
+    assert count == 42
+    assert resource.calls[-1][0] == "list"
+    assert resource.calls[-1][2]["per_page"] == 1
+
+
+def test_random():
+    resource = MockResource()
+    query = Query(resource)
+
+    result = query.random()
+    assert result["id"] == "random"
+    assert resource.calls[-1][0] == "random"
+
+
+def test_autocomplete():
+    resource = MockResource()
+    query = Query(resource)
+
+    result = query.autocomplete("einstein")
+    assert result.meta.count == 5
+    assert resource.calls[-1] == ("autocomplete", "einstein", {})


### PR DESCRIPTION
## Summary
This PR enhances the Query class to provide a more complete fluent interface similar to PyAlex, improving developer experience and API consistency.

## Changes
- ✨ Added logical filter operations:
  - `filter_or()` - OR operations between filters
  - `filter_not()` - NOT operations on filter values
  - `filter_gt()` - Greater than comparisons
  - `filter_lt()` - Less than comparisons
- ✨ Added `search_filter()` for field-specific searches
- ✨ Added `__getitem__` support for direct entity retrieval
- ✨ Added utility methods: `count()`, `random()`, `autocomplete()`
- ✨ Added `get()` as an alias for `list()` to match PyAlex conventions
- 🧪 Added comprehensive test coverage for all new features

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f5b69fac832bb6469a4d135e157b