### PR TITLE
feat: add PyAlex-style entity classes for direct access (Phase 2)

### DIFF
--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -42,6 +42,19 @@ __license__ = "MIT"
 
 from .client import AsyncOpenAlex, OpenAlex, async_client, client  # noqa: E402
 from .config import OpenAlexConfig  # noqa: E402
+from .entities import (  # noqa: E402
+    Authors,
+    Concepts,
+    Funders,
+    Institutions,
+    Journals,
+    Keywords,
+    People,
+    Publishers,
+    Sources,
+    Topics,
+    Works,
+)
 from .exceptions import (  # noqa: E402
     APIError,
     AuthenticationError,
@@ -259,6 +272,19 @@ __all__ = [  # noqa: RUF022
     "is_retryable_error",
     "rate_limited",
     "with_retry",
+    # Entity classes
+    "Works",
+    "Authors",
+    "Institutions",
+    "Sources",
+    "Topics",
+    "Publishers",
+    "Funders",
+    "Keywords",
+    "Concepts",
+    # Aliases
+    "People",
+    "Journals",
 ]
 
 # When running under pytest with ``pytest-httpx`` installed, placeholder tests

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -1,0 +1,239 @@
+"""Convenience entity classes for PyAlex-style direct access."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+
+from .models import (
+    Author,
+    AuthorsFilter,
+    BaseFilter,
+    Concept,
+    Funder,
+    Institution,
+    InstitutionsFilter,
+    Keyword,
+    Publisher,
+    Source,
+    Topic,
+    Work,
+    WorksFilter,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .models import ListResult
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .query import Query
+    from .resources.base import AsyncBaseResource, BaseResource
+    from .utils import Paginator
+
+from .client import AsyncOpenAlex, OpenAlex
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .config import OpenAlexConfig
+
+T = TypeVar("T")
+F = TypeVar("F", bound="BaseFilter")
+
+
+class BaseEntity(Generic[T, F]):
+    """Base class for entity convenience wrappers."""
+
+    resource_name: str = ""
+
+    def __init__(
+        self,
+        email: str | None = None,
+        api_key: str | None = None,
+        config: OpenAlexConfig | None = None,
+    ) -> None:
+        """Initialize entity with optional configuration."""
+        self._config = config
+        self._email = email
+        self._api_key = api_key
+        self._client: OpenAlex | None = None
+        self._async_client: AsyncOpenAlex | None = None
+
+    @property
+    def _sync_client(self) -> OpenAlex:
+        """Get or create sync client."""
+        if self._client is None:
+            self._client = OpenAlex(
+                config=self._config,
+                email=self._email,
+                api_key=self._api_key,
+            )
+        return self._client
+
+    @property
+    def _get_async_client(self) -> AsyncOpenAlex:
+        """Get or create async client."""
+        if self._async_client is None:
+            self._async_client = AsyncOpenAlex(
+                config=self._config,
+                email=self._email,
+                api_key=self._api_key,
+            )
+        return self._async_client
+
+    @property
+    def _resource(self) -> BaseResource[T, F]:
+        """Get the sync resource."""
+        return cast(
+            "BaseResource[T, F]", getattr(self._sync_client, self.resource_name)
+        )
+
+    @property
+    def _async_resource(self) -> AsyncBaseResource[T, F]:
+        """Get the async resource."""
+        return cast(
+            "AsyncBaseResource[T, F]",
+            getattr(self._get_async_client, self.resource_name),
+        )
+
+    def __getitem__(self, record_id: str | list[str]) -> T | ListResult[T]:
+        """Get entity by ID or list of IDs."""
+        return self.query()[record_id]
+
+    def query(self) -> Query[T, F]:
+        """Create a query builder."""
+        return self._resource.query()
+
+    def filter(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with filters."""
+        return self.query().filter(**kwargs)
+
+    def filter_or(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with OR filters."""
+        return self.query().filter_or(**kwargs)
+
+    def filter_not(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with NOT filters."""
+        return self.query().filter_not(**kwargs)
+
+    def filter_gt(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with greater than filters."""
+        return self.query().filter_gt(**kwargs)
+
+    def filter_lt(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with less than filters."""
+        return self.query().filter_lt(**kwargs)
+
+    def search(self, query: str) -> Query[T, F]:
+        """Create query with search."""
+        return self.query().search(query)
+
+    def search_filter(self, **kwargs: Any) -> Query[T, F]:
+        """Create query with search filters."""
+        return self.query().search_filter(**kwargs)
+
+    def sort(self, **kwargs: str) -> Query[T, F]:
+        """Create query with sorting."""
+        return self.query().sort(**kwargs)
+
+    def select(self, fields: list[str] | str) -> Query[T, F]:
+        """Create query with field selection."""
+        return self.query().select(fields)
+
+    def sample(self, n: int, seed: int | None = None) -> Query[T, F]:
+        """Create query with sampling."""
+        return self.query().sample(n, seed)
+
+    def group_by(self, key: str) -> Query[T, F]:
+        """Create query with grouping."""
+        return self.query().group_by(key)
+
+    def get(self, id: str | None = None, **params: Any) -> T | ListResult[T]:
+        """Get a single entity by ID or list entities."""
+        if id is not None:
+            return self._resource.get(id, **params)
+        return self.query().get(**params)
+
+    def list(self, **params: Any) -> ListResult[T]:
+        """List entities."""
+        return self.query().list(**params)
+
+    def count(self) -> int:
+        """Get count of all entities."""
+        return self.query().count()
+
+    def random(self) -> T:
+        """Get a random entity."""
+        return self._resource.random()
+
+    def autocomplete(self, query: str, **params: Any) -> ListResult[Any]:
+        """Autocomplete search."""
+        return self._resource.autocomplete(query, **params)
+
+    def paginate(self, **kwargs: Any) -> Paginator[T]:
+        """Create paginator."""
+        return self.query().paginate(**kwargs)
+
+    async def __aenter__(self) -> BaseEntity[T, F]:
+        """Async context manager entry."""
+        await self._get_async_client.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """Async context manager exit."""
+        if self._async_client:
+            await self._async_client.__aexit__(*args)
+
+
+class Works(BaseEntity[Work, WorksFilter]):
+    """Convenience class for Works resource."""
+
+    resource_name = "works"
+
+
+class Authors(BaseEntity[Author, AuthorsFilter]):
+    """Convenience class for Authors resource."""
+
+    resource_name = "authors"
+
+
+class Institutions(BaseEntity[Institution, InstitutionsFilter]):
+    """Convenience class for Institutions resource."""
+
+    resource_name = "institutions"
+
+
+class Sources(BaseEntity[Source, BaseFilter]):
+    """Convenience class for Sources resource."""
+
+    resource_name = "sources"
+
+
+class Topics(BaseEntity[Topic, BaseFilter]):
+    """Convenience class for Topics resource."""
+
+    resource_name = "topics"
+
+
+class Publishers(BaseEntity[Publisher, BaseFilter]):
+    """Convenience class for Publishers resource."""
+
+    resource_name = "publishers"
+
+
+class Funders(BaseEntity[Funder, BaseFilter]):
+    """Convenience class for Funders resource."""
+
+    resource_name = "funders"
+
+
+class Keywords(BaseEntity[Keyword, BaseFilter]):
+    """Convenience class for Keywords resource."""
+
+    resource_name = "keywords"
+
+
+class Concepts(BaseEntity[Concept, BaseFilter]):
+    """Convenience class for Concepts resource (deprecated)."""
+
+    resource_name = "concepts"
+
+
+People = Authors
+Journals = Sources

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,163 @@
+"""Test convenience entity classes."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from openalex import Authors, Institutions, Works
+from openalex.models import ListResult
+
+
+class TestEntityClasses:
+    """Test entity convenience wrappers."""
+
+    def test_direct_id_access(self):
+        """Test direct access by ID."""
+        with patch("openalex.entities.OpenAlex") as mock_client_class:
+            mock_client = Mock()
+            mock_resource = Mock()
+            mock_query = Mock()
+            mock_client_class.return_value = mock_client
+            mock_client.works = mock_resource
+            mock_resource.query.return_value = mock_query
+            mock_query.__getitem__ = Mock(
+                return_value={"id": "W123", "title": "Test"}
+            )
+            works = Works()
+            result = works["W123"]
+            assert result["id"] == "W123"
+            mock_query.__getitem__.assert_called_once_with("W123")
+
+    def test_filter_chain(self):
+        """Test filter method chaining."""
+        with patch("openalex.entities.OpenAlex") as mock_client_class:
+            mock_client = Mock()
+            mock_resource = Mock()
+            mock_query = Mock()
+            mock_client_class.return_value = mock_client
+            mock_client.authors = mock_resource
+            mock_resource.query.return_value = mock_query
+            mock_query.filter.return_value = mock_query
+            mock_query.search.return_value = mock_query
+            mock_query.sort.return_value = mock_query
+            mock_query.get.return_value = ListResult(
+                meta={
+                    "count": 10,
+                    "db_response_time_ms": 1,
+                    "page": 1,
+                    "per_page": 25,
+                },
+                results=[],
+            )
+            authors = Authors()
+            result = (
+                authors.filter(is_oa=True)
+                .search("einstein")
+                .sort(cited_by_count="desc")
+                .get()
+            )
+            assert result.meta.count == 10
+            mock_query.filter.assert_called_once_with(is_oa=True)
+            mock_query.search.assert_called_once_with("einstein")
+            mock_query.sort.assert_called_once_with(cited_by_count="desc")
+
+    def test_convenience_methods(self):
+        """Test all convenience methods create queries."""
+        with patch("openalex.entities.OpenAlex") as mock_client_class:
+            mock_client = Mock()
+            mock_resource = Mock()
+            mock_query = Mock()
+            mock_client_class.return_value = mock_client
+            mock_client.institutions = mock_resource
+            mock_resource.query.return_value = mock_query
+            mock_query.filter_or.return_value = mock_query
+            mock_query.filter_not.return_value = mock_query
+            mock_query.filter_gt.return_value = mock_query
+            mock_query.filter_lt.return_value = mock_query
+            mock_query.search_filter.return_value = mock_query
+            mock_query.group_by.return_value = mock_query
+            mock_query.select.return_value = mock_query
+            mock_query.sample.return_value = mock_query
+            inst = Institutions()
+            inst.filter_or(country="US")
+            mock_query.filter_or.assert_called_once()
+            inst.filter_not(type="company")
+            mock_query.filter_not.assert_called_once()
+            inst.filter_gt(works_count=1000)
+            mock_query.filter_gt.assert_called_once()
+            inst.filter_lt(works_count=100)
+            mock_query.filter_lt.assert_called_once()
+            inst.search_filter(display_name="MIT")
+            mock_query.search_filter.assert_called_once()
+            inst.group_by("type")
+            mock_query.group_by.assert_called_once()
+            inst.select(["id", "display_name"])
+            mock_query.select.assert_called_once()
+            inst.sample(10, seed=42)
+            mock_query.sample.assert_called_once_with(10, 42)
+
+    def test_direct_methods(self):
+        """Test direct execution methods."""
+        with patch("openalex.entities.OpenAlex") as mock_client_class:
+            mock_client = Mock()
+            mock_resource = Mock()
+            mock_client_class.return_value = mock_client
+            mock_client.works = mock_resource
+            mock_resource.get.return_value = {"id": "W123"}
+            mock_resource.random.return_value = {"id": "W789"}
+            mock_resource.autocomplete.return_value = ListResult(
+                meta={
+                    "count": 0,
+                    "db_response_time_ms": 1,
+                    "page": 1,
+                    "per_page": 25,
+                },
+                results=[],
+            )
+            works = Works()
+            result = works.get("W123")
+            assert result["id"] == "W123"
+            mock_resource.get.assert_called_once_with("W123")
+            random_work = works.random()
+            assert random_work["id"] == "W789"
+            works.autocomplete("climate")
+            mock_resource.autocomplete.assert_called_once_with("climate")
+
+    def test_config_propagation(self):
+        """Test configuration is properly passed to client."""
+        with patch("openalex.entities.OpenAlex") as mock_client_class:
+            Works(email="test@example.com").list()
+            mock_client_class.assert_called_with(
+                config=None,
+                email="test@example.com",
+                api_key=None,
+            )
+            mock_client_class.reset_mock()
+            Authors(api_key="test-key").list()
+            mock_client_class.assert_called_with(
+                config=None,
+                email=None,
+                api_key="test-key",
+            )
+
+    def test_aliases(self):
+        """Test entity aliases work correctly."""
+        from openalex import Journals, People
+
+        assert People.resource_name == "authors"
+        assert Journals.resource_name == "sources"
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self):
+        """Test async context manager support."""
+        with patch(
+            "openalex.entities.AsyncOpenAlex"
+        ) as mock_async_client_class:
+            mock_async_client = AsyncMock()
+            mock_async_client.__aenter__.return_value = mock_async_client
+            mock_async_client.__aexit__.return_value = None
+            mock_async_client_class.return_value = mock_async_client
+            async with Works() as works:
+                assert works is not None
+            mock_async_client.__aenter__.assert_called_once()
+            mock_async_client.__aexit__.assert_called_once()

--- a/tests/test_entity_usage.py
+++ b/tests/test_entity_usage.py
@@ -1,0 +1,23 @@
+"""Example usage patterns for entity classes."""
+
+from openalex import Authors, Institutions, Works
+
+
+def test_pyalex_style_usage():
+    """Demonstrate PyAlex-style usage patterns."""
+    Works()["W2741809807"]
+    Works().filter(publication_year=2020, is_oa=True).get()
+    (
+        Works()
+        .filter_gt(cited_by_count=100)
+        .filter_lt(publication_year=2020)
+        .search("machine learning")
+        .sort(cited_by_count="desc")
+        .get()
+    )
+    Authors().random()
+    Institutions().count()
+    Authors().autocomplete("einstein")
+    Works().filter(publication_year=2024).get()
+    Works().filter_gt(cited_by_count=1000).get()
+    Works().filter_or(topics={"id": "T10017"}, topics2={"id": "T10018"})


### PR DESCRIPTION
## Summary
Adds standalone entity classes enabling PyAlex-style direct access with both sync and async support. New convenience classes (e.g. `Works`, `Authors`) wrap the underlying client resources and expose the fluent `Query` API directly.

## Changes
- Implemented `openalex/entities.py` defining `BaseEntity` and resource-specific classes
- Exported entities and aliases in `openalex.__init__`
- Added comprehensive tests for entity behaviour and example usage

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f9df3cb4832b902512d6b02d645f