### PR TITLE
feat: implement filter serialization for logical operators (Phase 3)

### DIFF
--- a/openalex/resources/base.py
+++ b/openalex/resources/base.py
@@ -17,12 +17,9 @@ from ..constants import (
 from ..exceptions import ValidationError as OpenAlexValidationError
 from ..exceptions import raise_for_status
 from ..models import BaseFilter, ListResult
-from ..utils import (
-    AsyncPaginator,
-    Paginator,
-    normalize_params,
-)
+from ..utils import AsyncPaginator, Paginator
 from ..utils.pagination import MAX_PER_PAGE
+from ..utils.params import normalize_params
 
 if TYPE_CHECKING:
     from ..client import AsyncOpenAlex, OpenAlex

--- a/openalex/utils/__init__.py
+++ b/openalex/utils/__init__.py
@@ -7,13 +7,9 @@ from ..constants import (
     ORCID_URL_PREFIX,
     PMID_PREFIX,
 )
-from .common import (
-    empty_list_result,
-    ensure_prefix,
-    normalize_params,
-    strip_id_prefix,
-)
+from .common import empty_list_result, ensure_prefix, strip_id_prefix
 from .pagination import AsyncPaginator, Paginator
+from .params import normalize_params
 from .rate_limit import (
     AsyncRateLimiter,
     RateLimiter,

--- a/openalex/utils/params.py
+++ b/openalex/utils/params.py
@@ -1,0 +1,127 @@
+"""Parameter serialization utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote_plus
+
+from ..query import _LogicalExpression, or_
+from .common import KEY_MAP
+
+
+def serialize_filter_value(value: Any) -> str:
+    """Serialize a filter value for the API.
+
+    Handles:
+    - Logical expressions (not_, gt_, lt_)
+    - Lists (converted to pipe-separated values)
+    - Booleans (lowercase strings)
+    - Regular values (URL encoded)
+    """
+    # Handle logical expressions
+    if isinstance(value, _LogicalExpression):
+        # Recursively serialize the inner value
+        inner = serialize_filter_value(value.value)
+        return f"{value.token}{inner}"
+
+    # Handle booleans - OpenAlex expects lowercase
+    if isinstance(value, bool):
+        return str(value).lower()
+
+    # Handle lists - join with pipe for OR operation
+    if isinstance(value, list):
+        return "|".join(serialize_filter_value(v) for v in value)
+
+    # Handle None/null
+    if value is None:
+        return "null"
+
+    # URL encode strings and other values
+    return quote_plus(str(value))
+
+
+def flatten_filter_dict(
+    filters: dict[str, Any],
+    prefix: str = "",
+    logical: str = ",",
+) -> str:
+    """Flatten a nested filter dictionary into OpenAlex filter syntax.
+
+    Args:
+        filters: Dictionary of filters
+        prefix: Prefix for nested keys
+        logical: Logical operator ("," for AND, "|" for OR)
+
+    Returns:
+        Flattened filter string
+    """
+    if not filters:
+        return ""
+
+    # Handle or_ dictionaries with OR logic
+    if isinstance(filters, or_):
+        logical = "|"
+
+    parts = []
+
+    for key, value in filters.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+
+        if isinstance(value, dict) and not isinstance(value, or_):
+            # Nested dictionary - recurse
+            nested = flatten_filter_dict(value, full_key, ",")
+            if nested:
+                parts.append(nested)
+        else:
+            # Terminal value - serialize it
+            serialized = serialize_filter_value(value)
+            parts.append(f"{full_key}:{serialized}")
+
+    return logical.join(parts)
+
+
+def serialize_params(params: dict[str, Any]) -> dict[str, str]:
+    """Serialize parameters for API requests.
+
+    Handles special serialization for:
+    - filter: Complex nested structures with logical operators
+    - sort: Key:value pairs joined by commas
+    - select: List to comma-separated string
+    - Standard values: Convert to strings
+    """
+    serialized: dict[str, str] = {}
+
+    for key, value in params.items():
+        if key == "filter" and isinstance(value, dict):
+            filter_str = flatten_filter_dict(value)
+            if filter_str:
+                serialized["filter"] = filter_str
+        elif key == "sort" and isinstance(value, dict):
+            sort_parts = [f"{k}:{v}" for k, v in value.items()]
+            serialized["sort"] = ",".join(sort_parts)
+        elif key == "select" and isinstance(value, list):
+            serialized["select"] = ",".join(value)
+        elif value is not None:
+            if isinstance(value, bool):
+                serialized[key] = str(value).lower()
+            else:
+                serialized[key] = str(value)
+
+    return serialized
+
+
+# Update existing normalize_params if it exists
+def normalize_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Normalize parameters for API requests."""
+    # Remove None values
+    cleaned = {k: v for k, v in params.items() if v is not None}
+
+    # Serialize complex structures
+    serialized = serialize_params(cleaned)
+
+    normalized: dict[str, Any] = {}
+    for key, value in serialized.items():
+        new_key = KEY_MAP.get(key, key)
+        normalized[new_key] = value
+
+    return normalized

--- a/tests/test_filter_serialization.py
+++ b/tests/test_filter_serialization.py
@@ -1,0 +1,160 @@
+"""Test filter serialization for API requests."""
+
+from __future__ import annotations
+
+from openalex.query import gt_, lt_, not_, or_
+from openalex.utils.params import (
+    flatten_filter_dict,
+    serialize_filter_value,
+    serialize_params,
+)
+
+
+class TestFilterValueSerialization:
+    """Test individual filter value serialization."""
+
+    def test_logical_expressions(self) -> None:
+        """Test logical expression serialization."""
+        assert serialize_filter_value(not_("article")) == "!article"
+        assert serialize_filter_value(gt_(100)) == ">100"
+        assert serialize_filter_value(lt_(2020)) == "<2020"
+
+    def test_boolean_values(self) -> None:
+        """Test boolean serialization to lowercase."""
+        assert serialize_filter_value(True) == "true"
+        assert serialize_filter_value(False) == "false"
+
+    def test_list_values(self) -> None:
+        """Test list serialization with pipe separator."""
+        assert serialize_filter_value(["A", "B", "C"]) == "A|B|C"
+        assert serialize_filter_value([1, 2, 3]) == "1|2|3"
+
+    def test_none_value(self) -> None:
+        """Test None serialization."""
+        assert serialize_filter_value(None) == "null"
+
+    def test_url_encoding(self) -> None:
+        """Test URL encoding of special characters."""
+        assert serialize_filter_value("hello world") == "hello+world"
+        assert (
+            serialize_filter_value("test@example.com") == "test%40example.com"
+        )
+
+    def test_nested_logical_expressions(self) -> None:
+        """Test nested logical expressions."""
+        assert serialize_filter_value([not_("A"), "B"]) == "!A|B"
+        assert serialize_filter_value(gt_("hello world")) == ">hello+world"
+
+
+class TestFilterDictFlattening:
+    """Test filter dictionary flattening."""
+
+    def test_simple_filters(self) -> None:
+        """Test simple filter flattening."""
+        filters = {"is_oa": True, "type": "article"}
+        result = flatten_filter_dict(filters)
+        assert result == "is_oa:true,type:article"
+
+    def test_nested_filters(self) -> None:
+        """Test nested filter flattening."""
+        filters = {
+            "authorships": {
+                "author": {"id": "A123"},
+                "institutions": {"country_code": "US"},
+            }
+        }
+        result = flatten_filter_dict(filters)
+        assert "authorships.author.id:A123" in result
+        assert "authorships.institutions.country_code:US" in result
+
+    def test_or_filters(self) -> None:
+        """Test OR filter flattening."""
+        filters = or_({"type": "article", "is_oa": True})
+        result = flatten_filter_dict(filters)
+        assert result == "type:article|is_oa:true"
+
+    def test_complex_filters(self) -> None:
+        """Test complex filter combinations."""
+        filters = {
+            "is_oa": True,
+            "publication_year": gt_(2020),
+            "cited_by_count": lt_(100),
+            "type": not_("retracted"),
+            "institutions": {"country_code": ["US", "UK", "CA"]},
+        }
+        result = flatten_filter_dict(filters)
+        assert "is_oa:true" in result
+        assert "publication_year:>2020" in result
+        assert "cited_by_count:<100" in result
+        assert "type:!retracted" in result
+        assert "institutions.country_code:US|UK|CA" in result
+
+    def test_search_filters(self) -> None:
+        """Test search filter syntax."""
+        filters = {
+            "title.search": "quantum computing",
+            "abstract.search": "machine learning",
+        }
+        result = flatten_filter_dict(filters)
+        assert "title.search:quantum+computing" in result
+        assert "abstract.search:machine+learning" in result
+
+
+class TestParamSerialization:
+    """Test full parameter serialization."""
+
+    def test_full_params(self) -> None:
+        """Test serialization of all parameter types."""
+        params = {
+            "filter": {
+                "is_oa": True,
+                "publication_year": gt_(2020),
+                "type": ["article", "dataset"],
+            },
+            "sort": {"cited_by_count": "desc", "publication_year": "asc"},
+            "select": ["id", "title", "doi"],
+            "per_page": 50,
+            "page": 2,
+            "search": "climate change",
+        }
+        result = serialize_params(params)
+        assert "filter" in result
+        assert "is_oa:true" in result["filter"]
+        assert "publication_year:>2020" in result["filter"]
+        assert "type:article|dataset" in result["filter"]
+        assert result["sort"] == "cited_by_count:desc,publication_year:asc"
+        assert result["select"] == "id,title,doi"
+        assert result["per_page"] == "50"
+        assert result["page"] == "2"
+        assert result["search"] == "climate change"
+
+    def test_empty_params(self) -> None:
+        """Test empty parameter handling."""
+        assert serialize_params({}) == {}
+        assert serialize_params({"filter": {}}) == {}
+        assert serialize_params({"filter": None}) == {}
+
+
+class TestIntegration:
+    """Test integration with Query class."""
+
+    def test_query_to_params(self) -> None:
+        """Test Query object parameter generation."""
+        from openalex.query import Query
+
+        class MockResource:
+            def list(self, filter=None, **params):
+                return {"filter": filter, "params": params}
+
+        resource = MockResource()
+        query = (
+            Query(resource)
+            .filter_gt(cited_by_count=100)
+            .filter_not(type="retracted")
+            .filter_or(is_oa=True, has_doi=True)
+            .search("neuroscience")
+            .sort(publication_year="desc")
+        )
+        assert "filter" in query.params
+        assert "search" in query.params
+        assert "sort" in query.params

--- a/tests/test_serialization_integration.py
+++ b/tests/test_serialization_integration.py
@@ -1,0 +1,44 @@
+"""Test filter serialization in actual API calls."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from openalex import Works
+
+
+def test_complex_query_serialization() -> None:
+    """Test that complex queries are properly serialized."""
+    with patch("httpx.Client.request") as mock_request:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": [],
+            "meta": {
+                "count": 0,
+                "db_response_time_ms": 1,
+                "page": 1,
+                "per_page": 50,
+            },
+        }
+        mock_request.return_value = mock_response
+
+        (
+            Works()
+            .filter_gt(cited_by_count=100)
+            .filter_not(type="retracted")
+            .filter(is_oa=True)
+            .search("climate change")
+            .sort(publication_year="desc")
+            .get(per_page=50)
+        )
+
+        mock_request.assert_called_once()
+        _, kwargs = mock_request.call_args
+        params = kwargs.get("params", {})
+        assert "filter" in params
+        assert "cited_by_count:>100" in params["filter"]
+        assert "type:!retracted" in params["filter"]
+        assert "is_oa:true" in params["filter"]
+        assert params.get("search") == "climate change"
+        assert params.get("sort") == "publication_year:desc"
+        assert params.get("per-page") == "50"

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -19,7 +19,7 @@ def test_strip_id_prefix() -> None:
 def test_normalize_params_select_list() -> None:
     params = normalize_params({"select": ["id", "name"], "per_page": 5})
     assert params["select"] == "id,name"
-    assert params["per-page"] == 5
+    assert params["per-page"] == "5"
 
 
 def test_empty_list_result() -> None:


### PR DESCRIPTION
## Summary
Implemented serialization utilities for logical operators and complex filter structures, enabling proper API parameter generation.

Adjusted a unit test to reflect new parameter normalization behavior.

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848024676d8832ba5d2b9565700eafc