### PR TITLE
docs: update to PyAlex-style interface

### DIFF
--- a/docs/filter-authors.md
+++ b/docs/filter-authors.md
@@ -1,51 +1,66 @@
 # Filter authors
 
-Use the `filter` argument of `authors.list()` to narrow the results.
+Filter authors using various criteria:
 
 ```python
 from openalex import Authors
 
-authors = Authors()
-# authors that have an ORCID
-authors = authors.list(filter={"has_orcid": True})
-```
+# Authors with ORCID
+authors_with_orcid = Authors().filter(has_orcid=True).get()
 
-Multiple filters may be combined using a dictionary or the `AuthorsFilter` helper:
-
-```python
-params = {"has_orcid": True, "last_known_institution.continent": "africa"}
-results = authors.list(filter=params)
-
-filt = (
-    AuthorsFilter()
-    .with_orcid("!null")
-    .with_last_known_institution_continent("africa")
+# Multiple filters
+african_authors = (
+    Authors()
+    .filter(
+        has_orcid=True,
+        last_known_institution={"continent": "africa"}
+    )
+    .get()
 )
-results = authors.list(filter=filt)
 ```
 
-## Attribute filters
-
-Attribute filters correspond to fields on the `Author` object such as
-`orcid`, `works_count`, or `last_known_institution.id`.
-Pass them directly as keys in the filter dictionary or via `AuthorsFilter`.
+## Search Filters
 
 ```python
-params = {"works_count": ">100", "last_known_institution.id": "I27837315"}
-results = authors.list(filter=params)
+# Search in display name
+smiths = Authors().filter(display_name.search="smith").get()
+
+# Search with other filters
+prolific_johns = (
+    Authors()
+    .filter(display_name.search="john")
+    .filter_gt(works_count=50)
+    .get()
+)
 ```
 
-## Convenience filters
-
-Convenience filters are shortcuts for common queries that aren't single fields.
+## Range Filters
 
 ```python
-# search within the display name and require an ORCID
-params = {"display_name.search": "tupolev", "has_orcid": True}
-results = authors.list(filter=params)
+# Highly cited authors
+highly_cited = Authors().filter_gt(cited_by_count=1000).get()
+
+# Authors with moderate publication count
+moderate_publishers = (
+    Authors()
+    .filter_gt(works_count=10)
+    .filter_lt(works_count=100)
+    .get()
+)
 ```
 
-More examples include `default.search`, `last_known_institution.is_global_south`,
-and range filters for cited-by counts. See the
-[OpenAlex API documentation](https://docs.openalex.org/api-entities/authors/filter-authors)
-for the complete list.
+## Institution Filters
+
+```python
+# Authors from a specific institution
+mit_authors = Authors().filter(
+    last_known_institution={"id": "I63966007"}
+).get()
+
+# Authors from US institutions
+us_authors = Authors().filter(
+    last_known_institution={"country_code": "US"}
+).get()
+```
+
+For more filter options, see the [OpenAlex API documentation](https://docs.openalex.org/api-entities/authors/filter-authors).

--- a/docs/filter-concepts.md
+++ b/docs/filter-concepts.md
@@ -12,15 +12,11 @@ concepts = Concepts()
 level_zero = concepts.list(filter={"level": 0})
 ```
 
-Combine multiple filters or use the `ConceptsFilter` helper:
+Combine multiple filters using a dictionary:
 
 ```python
 params = {"cited_by_count": ">100", "has_wikidata": True}
 results = concepts.list(filter=params)
-
-from openalex import ConceptsFilter
-filt = ConceptsFilter().with_level(1).with_has_wikidata(True)
-results = concepts.list(filter=filt)
 ```
 
 See [the API docs](https://docs.openalex.org/api-entities/concepts/filter-concepts) for the full list of attribute and convenience filters.

--- a/docs/filter-funders.md
+++ b/docs/filter-funders.md
@@ -9,16 +9,11 @@ funders = Funders()
 canadian = funders.list(filter={"country_code": "ca"})
 ```
 
-Combine multiple filters or use the `FundersFilter` helper:
+Combine multiple filters using a dictionary:
 
 ```python
 params = {"country_code": "us", "is_global_south": False}
 results = funders.list(filter=params)
-
-from openalex import FundersFilter
-
-filt = FundersFilter().with_country_code("us").with_grants_count_range(min_count=100)
-results = funders.list(filter=filt)
 ```
 
 Attribute filters include fields like `works_count`, `cited_by_count`, and `grants_count`.

--- a/docs/filter-institutions.md
+++ b/docs/filter-institutions.md
@@ -16,15 +16,6 @@ params = {"country_code": "us", "type": "education"}
 results = institutions.list(filter=params)
 ```
 
-A fluent `InstitutionsFilter` is also available:
-
-```python
-from openalex import InstitutionsFilter
-
-filt = InstitutionsFilter().with_country_code("us").with_type("education")
-results = institutions.list(filter=filt)
-```
-
 Other attribute filters include `ror`, `works_count`, and `cited_by_count`.
 
 Convenience filters provide shortcuts for common operations, for example:

--- a/docs/filter-publishers.md
+++ b/docs/filter-publishers.md
@@ -10,18 +10,11 @@ publishers = Publishers()
 publishers = publishers.list(filter={"hierarchy_level": 0})
 ```
 
-Combine several filters with a dictionary or the `PublishersFilter` helper:
+Combine several filters with a dictionary:
 
 ```python
 params = {"country_codes": "US", "hierarchy_level": 0}
 results = publishers.list(filter=params)
-
-filt = (
-    PublishersFilter()
-    .with_country_codes("US")
-    .with_hierarchy_level(0)
-)
-results = publishers.list(filter=filt)
 ```
 
 Other useful fields include `parent_publisher`, ranges on `works_count`, and text search using `display_name.search`.

--- a/docs/filter-sources.md
+++ b/docs/filter-sources.md
@@ -10,18 +10,11 @@ sources = Sources()
 sources = sources.list(filter={"has_issn": True})
 ```
 
-Multiple filters can be combined with a dictionary or the `SourcesFilter` helper:
+Combine multiple filters using a dictionary:
 
 ```python
 params = {"is_oa": True, "host_organization.id": "P4310320547"}
 results = sources.list(filter=params)
-
-filt = (
-    SourcesFilter()
-    .with_is_oa(is_oa=True)
-    .with_publisher("P4310320547")
-)
-results = sources.list(filter=filt)
 ```
 
 Other useful filters include ranges like `apc_usd`, `summary_stats.h_index` and text search using `display_name.search`.

--- a/docs/filter-topics.md
+++ b/docs/filter-topics.md
@@ -9,15 +9,11 @@ topics = Topics()
 epi = topics.list(filter={"subfield.id": 2713})
 ```
 
-You can combine parameters or use the `TopicsFilter` helper:
+Combine parameters using a dictionary:
 
 ```python
 params = {"field.id": 1047, "works_count": ">1000"}
 results = topics.list(filter=params)
-
-from openalex import TopicsFilter
-filt = TopicsFilter().with_domain_id(4100).with_cited_by_count_range(min_count=50)
-results = topics.list(filter=filt)
 ```
 
 See [OpenAlex filter docs](https://docs.openalex.org/api-entities/topics/filter-topics) for a complete list of attribute and convenience filters.

--- a/docs/get-a-single-work.md
+++ b/docs/get-a-single-work.md
@@ -1,6 +1,6 @@
 # Get a single work
 
-Use the client to fetch a `Work` by its OpenAlex identifier.
+Use `Works()` to fetch a `Work` by its OpenAlex identifier.
 
 ```python
 from openalex import Works
@@ -28,12 +28,12 @@ work = works.get("pmid:14907713")
 
 Supported prefixes:
 
-| External ID | Prefix |
-|-------------|-------|
-| DOI | `doi:` |
-| Microsoft Academic Graph (MAG) | `mag:` |
-| PubMed ID (PMID) | `pmid:` |
-| PubMed Central ID (PMCID) | `pmcid:` |
+| External ID                    | Prefix   |
+| ------------------------------ | -------- |
+| DOI                            | `doi:`   |
+| Microsoft Academic Graph (MAG) | `mag:`   |
+| PubMed ID (PMID)               | `pmid:`  |
+| PubMed Central ID (PMCID)      | `pmcid:` |
 
 Make sure the identifier is valid. Invalid or malformed IDs will either return no result or raise an error.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,44 +1,72 @@
 # OpenAlex Python Client Documentation
 
-Short examples showing how to accomplish common tasks with the Python client.
+A modern Python client for OpenAlex with a fluent, chainable interface and full type annotations.
 
-- [Get a single work](get-a-single-work.md)
-- [Get lists of works](get-lists-of-works.md)
-- [Filter works](filter-works.md)
-- [Search works](search-works.md)
-- [Group works](group-works.md)
-- [Get a single author](get-a-single-author.md)
-- [Get lists of authors](get-lists-of-authors.md)
-- [Filter authors](filter-authors.md)
-- [Search authors](search-authors.md)
-- [Group authors](group-authors.md)
-- [Get a single source](get-a-single-source.md)
-- [Get lists of sources](get-lists-of-sources.md)
-- [Filter sources](filter-sources.md)
-- [Search sources](search-sources.md)
-- [Group sources](group-sources.md)
-- [Get a single publisher](get-a-single-publisher.md)
-- [Get lists of publishers](get-lists-of-publishers.md)
-- [Filter publishers](filter-publishers.md)
-- [Search publishers](search-publishers.md)
-- [Group publishers](group-publishers.md)
-- [Get a single institution](get-a-single-institution.md)
-- [Get lists of institutions](get-lists-of-institutions.md)
-- [Filter institutions](filter-institutions.md)
-- [Search institutions](search-institutions.md)
-- [Group institutions](group-institutions.md)
-- [Get a single funder](get-a-single-funder.md)
-- [Get lists of funders](get-lists-of-funders.md)
-- [Filter funders](filter-funders.md)
-- [Search funders](search-funders.md)
-- [Group funders](group-funders.md)
-- [Get a single topic](get-a-single-topic.md)
-- [Get lists of topics](get-lists-of-topics.md)
-- [Filter topics](filter-topics.md)
-- [Search topics](search-topics.md)
-- [Group topics](group-topics.md)
-- [Get a single concept](get-a-single-concept.md)
-- [Get lists of concepts](get-lists-of-concepts.md)
-- [Filter concepts](filter-concepts.md)
-- [Search concepts](search-concepts.md)
-- [Group concepts](group-concepts.md)
+## Quick Start
+
+```python
+from openalex import Works, Authors
+
+# Get a work by ID
+work = Works()["W2741809807"]
+
+# Search and filter
+papers = (
+    Works()
+    .search("climate change")
+    .filter(publication_year=2023, is_oa=True)
+    .get()
+)
+
+# Complex queries
+results = (
+    Works()
+    .filter_gt(cited_by_count=10)
+    .filter_not(type="retracted")
+    .sort(publication_year="desc")
+    .get()
+)
+```
+
+## Available Entities
+
+Each entity supports the same fluent interface:
+
+- [Works](get-a-single-work.md) - Academic papers, books, datasets
+- [Authors](get-a-single-author.md) - Researchers
+- [Institutions](get-a-single-institution.md) - Universities and organizations
+- [Sources](get-a-single-source.md) - Journals and repositories
+- [Topics](get-a-single-topic.md) - Research topics
+- [Publishers](get-a-single-publisher.md) - Academic publishers
+- [Funders](get-a-single-funder.md) - Funding organizations
+- [Concepts](get-a-single-concept.md) - Research concepts (deprecated)
+
+## Common Operations
+
+- **Get by ID**: `Works()["W123"]`
+- **Filter**: `.filter(is_oa=True)`
+- **Search**: `.search("quantum")`
+- **Sort**: `.sort(cited_by_count="desc")`
+- **Select fields**: `.select(["id", "title"])`
+- **Paginate**: `.paginate()`
+- **Group by**: `.group_by("oa_status")`
+
+## Logical Operations
+
+- **OR**: `.filter_or(type="article", type="preprint")`
+- **NOT**: `.filter_not(is_retracted=True)`
+- **Greater than**: `.filter_gt(cited_by_count=100)`
+- **Less than**: `.filter_lt(publication_year=2020)`
+
+## Configuration
+
+```python
+from openalex import Works, OpenAlexConfig
+
+config = OpenAlexConfig(
+    email="your-email@example.com",  # For polite pool
+    api_key="your-api-key",  # For premium access
+)
+
+works = Works(config=config)
+```

--- a/docs/search-authors.md
+++ b/docs/search-authors.md
@@ -1,39 +1,48 @@
 # Search authors
 
-Use `authors.search()` to look up authors by name.
+Search for authors by name:
 
 ```python
 from openalex import Authors
 
-authors = Authors()
-results = authors.search("carl sagan")
-print(results.results[0].display_name)
+# Simple search
+results = Authors().search("marie curie").get()
+
+# Get the first result
+if results.results:
+    author = results.results[0]
+    print(f"{author.display_name} - {author.works_count} works")
 ```
 
-See the [OpenAlex documentation](https://docs.openalex.org/api-entities/authors/search-authors)
-for details on how search scoring works.
-
-## Search a specific field
-
-Search can also be used as a filter by appending `.search` to a field:
+## Search with Filters
 
 ```python
-results = authors.list(filter={"display_name.search": "john smith"})
+# Search with additional criteria
+physicists = (
+    Authors()
+    .search("einstein")
+    .filter(last_known_institution={"country_code": "US"})
+    .get()
+)
 ```
 
-When searching authors there is effectively no difference between the `search` parameter
-and the filter `display_name.search` since the name is the only searchable field.
+## Field-Specific Search
 
-| Search filter | Field that is searched |
-|---------------|-----------------------|
-| `display_name.search` | `display_name` |
-
-## Autocomplete authors
-
-Use `authors.autocomplete()` to get quick suggestions for a typeahead widget:
+For authors, searching the display name is the primary option:
 
 ```python
-suggestions = authors.autocomplete("ronald sw")
+# Equivalent to search()
+authors = Authors().filter(display_name.search="feynman").get()
 ```
 
-Each suggestion includes the author's current institution as a hint.
+## Autocomplete
+
+Get suggestions for author names:
+
+```python
+suggestions = Authors().autocomplete("carl sa")
+for suggestion in suggestions.results:
+    print(f"{suggestion.display_name} - {suggestion.hint}")
+```
+
+The hint typically shows the author's institution.

--- a/docs/search-works.md
+++ b/docs/search-works.md
@@ -1,57 +1,79 @@
 # Search works
 
-Use `works.search()` to query titles, abstracts, and full text.
+Search across titles, abstracts, and full text:
 
 ```python
 from openalex import Works
 
-works = Works()
-results = works.search("dna")
-print(results.results[0].display_name)
+# Basic search
+results = Works().search("climate change").get()
+
+# Search with filters
+recent_climate_papers = (
+    Works()
+    .search("climate change")
+    .filter(publication_year=[2022, 2023])
+    .filter(is_oa=True)
+    .get()
+)
 ```
 
-Full text search only applies to works where `has_fulltext` is true.
+## Field-Specific Search
 
-See the [OpenAlex documentation](https://docs.openalex.org/api-entities/works/search-works) for details on how search ranking works and more advanced options.
-
-## Search a specific field
-
-Append `.search` to a filter key to limit searching to that field:
+Use `search_filter()` to search within specific fields:
 
 ```python
-works = works.list(filter={"title.search": "cubist"})
+# Search in title only
+title_matches = (
+    Works()
+    .search_filter(title="quantum computing")
+    .get()
+)
+
+# Search in abstract
+abstract_matches = (
+    Works()
+    .search_filter(abstract="machine learning")
+    .get()
+)
+
+# Multiple field searches
+specific_papers = (
+    Works()
+    .search_filter(
+        title="neural networks",
+        abstract="classification"
+    )
+    .get()
+)
 ```
 
-Fields that accept `.search` include `abstract`, `display_name` (alias `title`), `fulltext`, `raw_affiliation_strings`, and `title_and_abstract`. You can also use `default.search`, which behaves the same as the `search` parameter.
-
-| Search filter | Field that is searched |
-| --- | --- |
-| `abstract.search` | `abstract_inverted_index` |
-| `display_name.search` | `display_name` |
-| `fulltext.search` | fulltext via n-grams |
-| `raw_affiliation_strings.search` | `authorships.raw_affiliation_strings` |
-| `title.search` | `display_name` |
-| `title_and_abstract.search` | `display_name` and `abstract_inverted_index` |
-
-These searches apply stemming and stop-word removal. See the API docs if you need to disable this behaviour.
-
-### Searching by related entity names
-
-To search works by a related entity like an author or institution, first lookup that entity and then filter works by its ID:
+## Advanced Search
 
 ```python
-from openalex import Institutions
-
-nyu = Institutions().search("nyu").results[0]
-works = works.list(filter={"institutions.id": nyu.id})
+# Combine search with complex filters
+results = (
+    Works()
+    .search("artificial intelligence")
+    .filter(
+        publication_year=2023,
+        is_oa=True,
+        type="article"
+    )
+    .filter_gt(cited_by_count=5)
+    .sort(cited_by_count="desc")
+    .get()
+)
 ```
 
-## Autocomplete works
+## Autocomplete
 
-`works.autocomplete()` provides typeahead suggestions:
+Get suggestions for typeahead:
 
 ```python
-suggestions = works.autocomplete("tigers")
+suggestions = Works().autocomplete("quan")
+for suggestion in suggestions.results:
+    print(suggestion.display_name)
 ```
 
-Each suggestion includes the title and a hint containing the authors.
+See the [OpenAlex documentation](https://docs.openalex.org/api-entities/works/search-works) for more details on search behavior.

--- a/docs/type-safety.md
+++ b/docs/type-safety.md
@@ -1,0 +1,48 @@
+# Type Safety
+
+This client provides comprehensive type safety through Pydantic models:
+
+```python
+from openalex import Works
+
+# Full IDE autocomplete and type checking
+work = Works()["W2741809807"]
+print(work.title)  # str
+print(work.publication_year)  # int | None
+print(work.authorships[0].author.display_name)  # str
+
+# Type errors caught at development time
+# work.invalid_field  # <-- IDE/mypy error
+
+# Nested objects are fully typed
+for authorship in work.authorships:  # list[Authorship]
+    if authorship.author:  # DehydratedAuthor | None
+        print(authorship.author.orcid)  # str | None
+```
+
+## Benefits
+
+1. **IDE Autocomplete** - All fields are discoverable
+2. **Type Checking** - Catch errors before runtime
+3. **Documentation** - Types serve as documentation
+4. **Validation** - Pydantic validates API responses
+
+## Computed Properties
+
+Models include helpful computed properties:
+
+```python
+work = Works()["W2741809807"]
+
+# Automatic abstract conversion
+print(work.abstract)  # Converts inverted index to text
+
+# Helper methods
+print(work.has_references())  # bool
+print(work.open_access.is_oa)  # bool
+
+# Year-specific citations
+citations_2023 = work.citations_in_year(2023)  # int
+```
+
+This type safety is a major advantage over dictionary-based approaches.


### PR DESCRIPTION
## Summary
- rewrite documentation for PyAlex-style usage
- drop references to legacy filter builder classes
- add type safety guide
- remove client-based examples from docs

## Testing
- `prettier --write README.md docs/filter-authors.md docs/filter-concepts.md docs/filter-funders.md docs/filter-institutions.md docs/filter-publishers.md docs/filter-sources.md docs/filter-topics.md docs/filter-works.md docs/get-a-single-work.md docs/index.md docs/search-authors.md docs/search-works.md docs/type-safety.md`
- `mkdocs build` *(fails: Config file 'mkdocs.yml' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684831b055c8832bb551c4f9adda9521