### PR TITLE
Update work docs with Python client examples

### DIFF
--- a/docs/works/README.md
+++ b/docs/works/README.md
@@ -1,0 +1,42 @@
+---
+description: Journal articles, books, datasets, and theses
+---
+
+# \ud83d\udcc4 Works
+
+Works are scholarly documents like journal articles, books, datasets, and theses. OpenAlex indexes over 240M works, with about 50,000 added daily. You can access works in the OpenAlex Python client like this:
+
+```python
+from openalex import Works
+
+# Create a query builder for works (this doesn't fetch any data yet)
+works_query = Works()
+
+# Execute the query to get the first page of results (25 works by default)
+first_page = works_query.get()
+
+print(f"Total works in OpenAlex: {first_page.meta.count:,}")
+print(f"Works returned in this page: {len(first_page.results)}")
+```
+
+That will return a [`ListResult`](../models/list-result.md) containing [`Work`](work-object.md) objects, describing everything OpenAlex knows about each work. We collect new works from many sources, including Crossref, PubMed, institutional and discipline-specific repositories (eg, arXiv). Many older works come from the now-defunct Microsoft Academic Graph (MAG).
+
+Works are linked to other works via the `referenced_works` (outgoing citations), `cited_by_api_url` (incoming citations), and `related_works` properties.
+
+## Important: Understanding Query Results
+
+When you use `Works()`, you're creating a **query builder**, not fetching data. The data is only retrieved when you call:
+- `.get()` - Returns one page of results (25-200 items)
+- `.paginate()` - Returns an iterator for all results
+- `.group_by(...).get()` - Returns aggregated counts, not individual works
+
+## What's next
+
+Learn more about what you can do with works:
+
+* [The Work object](work-object.md)
+* [Get a single work](get-a-single-work.md)
+* [Get lists of works](get-lists-of-works.md)
+* [Filter works](filter-works.md)
+* [Search for works](search-works.md)
+* [Group works](group-works.md)

--- a/docs/works/filter-works.md
+++ b/docs/works/filter-works.md
@@ -1,0 +1,408 @@
+# Filter works
+
+It's easy to filter works using the Python client:
+
+```python
+from openalex import Works
+
+# Create a filtered query for works published in 2020
+works_2020_query = Works().filter(publication_year=2020)
+
+# Execute the query to get the first page of results
+results = works_2020_query.get()
+
+print(f"Total works from 2020: {results.meta.count:,}")  # e.g., 4,567,890
+print(f"Showing first {len(results.results)} works")  # 25
+```
+
+\ud83d\udca1 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+
+## Understanding filters vs. results
+
+```python
+# This creates a QUERY for ~5 million works from 2023
+query_2023 = Works().filter(publication_year=2023)
+
+# This fetches only the FIRST 25 of those millions
+first_page = query_2023.get()
+
+# To get more results, use pagination
+page2 = query_2023.get(page=2, per_page=100)  # Works 101-200
+
+# Or iterate through all results (use with caution!)
+for work in query_2023.paginate(per_page=200):
+    # This will make ~25,000 API calls to get all 5M works!
+    process(work)
+```
+
+## Works attribute filters
+
+You can filter using these attributes of the [`Work`](work-object.md) object:
+
+\u26a0\ufe0f The `host_venue` and `alternate_host_venues` properties have been deprecated in favor of `primary_location` and `locations`.
+
+### Basic attribute filters
+
+```python
+# Filter by DOI (returns at most one work)
+specific_work = Works().filter(doi="https://doi.org/10.1038/nature12373").get()
+
+# Filter by publication year
+recent_works = Works().filter(publication_year=2023).get()
+# Returns first 25 works from 2023 (out of millions)
+
+# Filter by year range using a list
+range_works = Works().filter(publication_year=[2020, 2021, 2022]).get()
+# Returns first 25 works from 2020-2022
+
+# Filter by open access status
+oa_works = Works().filter(open_access={"is_oa": True}).get()
+# Returns first 25 OA works (out of ~100 million)
+
+# Filter by work type
+research_articles = Works().filter(type="article").get()
+datasets = Works().filter(type="dataset").get()
+
+# Filter by language
+english_works = Works().filter(language="en").get()
+spanish_works = Works().filter(language="es").get()
+
+# Filter by citation count (exact match)
+exactly_100_citations = Works().filter(cited_by_count=100).get()
+```
+
+### Comparison operators
+
+```python
+# Greater than: find highly-cited works
+highly_cited = Works().filter_gt(cited_by_count=1000).get()
+# Returns first 25 works with >1000 citations
+
+# Less than: find recent works with fewer citations  
+less_cited = Works().filter_lt(cited_by_count=10).get()
+
+# Combine comparisons for ranges
+citation_range = (
+    Works()
+    .filter_gt(cited_by_count=100)
+    .filter_lt(cited_by_count=500)
+    .get()
+)
+# Returns works with 100 < citations < 500
+
+# Date comparisons
+recent = Works().filter_gt(publication_year=2020).get()
+older = Works().filter_lt(publication_year=2000).get()
+```
+
+### Author and institution filters
+
+```python
+# Find works by a specific author (using their OpenAlex ID)
+author_works = Works().filter(
+    authorships={"author": {"id": "A5023888391"}}
+).get()
+# Returns first 25 works by this author
+
+# Filter by author ORCID
+orcid_works = Works().filter(
+    authorships={"author": {"orcid": "https://orcid.org/0000-0001-6187-6610"}}
+).get()
+
+# Find works from a specific institution
+mit_works = Works().filter(
+    authorships={"institutions": {"id": "I63966007"}}
+).get()
+# Returns first 25 works where at least one author is from MIT
+
+# Filter by institution ROR ID
+ror_works = Works().filter(
+    authorships={"institutions": {"ror": "https://ror.org/042nb2s44"}}
+).get()
+
+# Filter by country (returns works with authors from these countries)
+us_works = Works().filter(
+    authorships={"institutions": {"country_code": "US"}}
+).get()
+
+# Multiple countries (OR operation within the list)
+international = Works().filter(
+    authorships={"institutions": {"country_code": ["US", "UK", "CA"]}}
+).get()
+# Returns works where authors are from US OR UK OR CA
+
+# Filter by corresponding author
+corresponding = Works().filter(authorships={"is_corresponding": True}).get()
+# Returns works that have corresponding author information
+```
+
+### Location and open access filters
+
+```python
+# Find works published in a specific journal
+nature_works = Works().filter(
+    primary_location={"source": {"id": "S137773608"}}
+).get()
+# Returns first 25 works published in Nature
+
+# Filter by license type
+cc_by_works = Works().filter(
+    best_oa_location={"license": "cc-by"}
+).get()
+# Returns works with Creative Commons BY license
+
+# Filter by version
+published_versions = Works().filter(
+    primary_location={"version": "publishedVersion"}
+).get()
+
+# Find works in specific repository
+arxiv_works = Works().filter(
+    locations={"source": {"id": "S4306402567"}}
+).get()
+# Returns works that have a copy in arXiv
+```
+
+### Topic and concept filters
+
+```python
+# Filter by primary topic (e.g., Machine Learning)
+ml_works = Works().filter(primary_topic={"id": "T10159"}).get()
+# Returns first 25 works about machine learning
+
+# Filter by topic domain (e.g., Health Sciences)
+health_works = Works().filter(
+    topics={"domain": {"id": "D4"}}
+).get()
+
+# Filter by concepts (deprecated but still available)
+medicine_works = Works().filter(concepts={"id": "C71924100"}).get()
+```
+
+## Convenience filters
+
+These filters aren't attributes of the Work object, but they're handy for common use cases:
+
+### Text search filters
+
+```python
+# Search in abstracts only
+ai_abstracts = Works().filter(
+    abstract={"search": "artificial intelligence"}
+).get()
+# Returns works with "artificial intelligence" in the abstract
+
+# Search in titles only
+climate_titles = Works().filter(
+    title={"search": "climate change"}
+).get()
+
+# Search in both title and abstract
+quantum_search = Works().filter(
+    title_and_abstract={"search": "quantum computing"}
+).get()
+
+# Full-text search (when available)
+ml_fulltext = Works().filter(
+    fulltext={"search": "machine learning algorithms"}
+).get()
+# Only searches works where we have full-text indexed
+
+# Search in author affiliation strings
+amsterdam_affiliations = Works().filter(
+    raw_affiliation_strings={"search": "University of Amsterdam"}
+).get()
+```
+
+### Count filters
+
+```python
+# Filter by number of authors
+single_author_works = Works().filter(authors_count=1).get()
+
+# Works with many authors (>10)
+collaborative_works = Works().filter_gt(authors_count=10).get()
+
+# Works with many concepts assigned
+interdisciplinary = Works().filter_gt(concepts_count=5).get()
+
+# International collaborations (3+ countries)
+international_collabs = Works().filter_gt(countries_distinct_count=3).get()
+```
+
+### Date range filters
+
+```python
+# Works published from a specific date onwards
+recent_works = Works().filter(from_publication_date="2023-01-01").get()
+# Returns first 25 works published after Jan 1, 2023
+
+# Works published before a date
+older_works = Works().filter(to_publication_date="2020-12-31").get()
+
+# Combine for a date range
+pandemic_era = Works().filter(
+    from_publication_date="2020-01-01",
+    to_publication_date="2023-12-31"
+).get()
+
+# Filter by when works were added to OpenAlex (requires API key)
+newly_added = Works().filter(from_created_date="2024-01-01").get()
+
+# Filter by when works were last updated
+recently_updated = Works().filter(from_updated_date="2024-06-01").get()
+```
+
+### Citation relationship filters
+
+```python
+# Find works that cite a specific paper
+citing_works = Works().filter(cites="W2741809807").get()
+# Returns first 25 works that reference W2741809807
+
+# Find works cited by a specific paper  
+references = Works().filter(cited_by="W2766808518").get()
+# Returns works in the reference list of W2766808518
+
+# Find related works (algorithmically determined)
+related = Works().filter(related_to="W2486144666").get()
+```
+
+### Boolean and existence filters
+
+```python
+# Check for presence of identifiers
+has_doi = Works().filter(has_doi=True).get()
+has_pmid = Works().filter(has_pmid=True).get()
+has_pmcid = Works().filter(has_pmcid=True).get()
+
+# Check for content availability  
+has_abstract = Works().filter(has_abstract=True).get()
+has_fulltext = Works().filter(has_fulltext=True).get()  # Has indexed full text
+has_references = Works().filter(has_references=True).get()
+
+# Check for author information
+has_orcid = Works().filter(has_orcid=True).get()
+# At least one author has ORCID
+
+# Special work types
+paratext_only = Works().filter(is_paratext=True).get()  # Editorials, TOCs, etc.
+retracted_works = Works().filter(is_retracted=True).get()
+
+# Open access version filters
+has_accepted_version = Works().filter(
+    has_oa_accepted_or_published_version=True
+).get()
+has_preprint = Works().filter(has_oa_submitted_version=True).get()
+```
+
+## Combining filters
+
+### AND operations (default)
+
+```python
+# Each filter() call adds an AND condition
+recent_ml_papers = (
+    Works()
+    .filter(publication_year=2023)  # AND
+    .filter(primary_topic={"id": "T10159"})  # AND
+    .filter(open_access={"is_oa": True})  # AND
+    .filter_gt(cited_by_count=10)
+    .get()
+)
+# Returns OA ML papers from 2023 with >10 citations
+# This is a very specific query that might return 0-100 results
+```
+
+### OR operations
+
+```python
+# OR within a single field (use list)
+multilingual = Works().filter(language=["en", "es", "fr"]).get()
+# Returns works in English OR Spanish OR French
+
+# OR between different values of same field
+article_or_preprint = Works().filter_or(
+    type="article",
+    type="preprint"
+).get()
+
+# OR with different fields requires multiple queries
+# (The API doesn't support OR across different fields)
+```
+
+### NOT operations
+
+```python
+# Exclude retracted works
+not_retracted = Works().filter_not(is_retracted=True).get()
+
+# Exclude specific types
+not_paratext = Works().filter_not(is_paratext=True).get()
+
+# Combine NOT with other filters
+good_recent_works = (
+    Works()
+    .filter(publication_year=2023)
+    .filter_not(is_retracted=True)
+    .filter_not(is_paratext=True)
+    .filter_gt(cited_by_count=5)
+    .get()
+)
+```
+
+## Nested filtering examples
+
+```python
+# Complex author-institution query
+harvard_chemists = Works().filter(
+    authorships={
+        "institutions": {
+            "id": "I136199984",  # Harvard
+            "lineage": "I136199984"  # Include sub-institutions
+        }
+    },
+    primary_topic={
+        "field": {"display_name": "Chemistry"}
+    }
+).get()
+
+# Multiple location criteria
+gold_oa_in_doaj = Works().filter(
+    locations={
+        "source": {
+            "is_in_doaj": True,
+            "type": "journal"
+        },
+        "is_oa": True,
+        "version": "publishedVersion"
+    }
+).get()
+
+# Grant-funded research
+nsf_funded_recent = Works().filter(
+    grants={"funder": "F4320306076"},  # NSF
+    publication_year=[2022, 2023, 2024]
+).get()
+```
+
+## Performance tips
+
+1. **Be specific**: More filters = fewer results = faster queries
+2. **Use select()**: Only fetch fields you need
+3. **Avoid paginating large result sets**: Use group_by for analytics
+4. **Check meta.count first**: See how many results match before paginating
+
+```python
+# Check result count before deciding to paginate
+query = Works().filter(authorships={"institutions": {"id": "I12345"}})
+first_page = query.get()
+
+if first_page.meta.count > 10000:
+    print(f"Warning: {first_page.meta.count:,} results!")
+    print("Consider adding more filters or using group_by")
+else:
+    # Safe to paginate through results
+    for work in query.paginate():
+        process(work)
+```

--- a/docs/works/get-a-single-work.md
+++ b/docs/works/get-a-single-work.md
@@ -1,0 +1,79 @@
+# Get a single work
+
+It's easy to get a work using the Python client. Here's an example:
+
+```python
+from openalex import Works
+
+# Get a specific work by its OpenAlex ID
+work = Works()["W2741809807"]
+
+# Alternative syntax using the get method
+work = Works().get("W2741809807")
+```
+
+That will return a [`Work`](work-object.md) object, describing everything OpenAlex knows about the work with that ID.
+
+```python
+# Access work properties directly as Python attributes
+print(work.id)  # "https://openalex.org/W2741809807"
+print(work.doi)  # "https://doi.org/10.7717/peerj.4375"
+print(work.title)  # "The state of OA: a large-scale analysis..."
+print(work.publication_year)  # 2018
+print(work.publication_date)  # "2018-02-13"
+```
+
+You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
+
+```python
+# Fetch multiple specific works in one API call
+ids = ["W2741809807", "W2755950973", "W2898525390"]
+multiple_works = Works().filter(openalex_id=ids).get()
+
+# This returns a page with up to 50 works (if all IDs are valid)
+print(f"Found {len(multiple_works.results)} works")
+```
+
+## External IDs
+
+You can look up works using external IDs such as a DOI:
+
+```python
+# Get work by DOI (multiple formats supported)
+work = Works()["https://doi.org/10.7717/peerj.4375"]
+work = Works()["doi:10.7717/peerj.4375"]  # Shorter URN format
+
+# Get work by PubMed ID
+work = Works()["pmid:14907713"]
+work = Works()["https://pubmed.ncbi.nlm.nih.gov/14907713"]  # Full URL also works
+
+# Get work by PubMed Central ID
+work = Works()["pmcid:PMC1394394"]
+
+# Get work by Microsoft Academic Graph ID
+work = Works()["mag:2741809807"]
+```
+
+Available external IDs for works are:
+
+| External ID                    | URN     |
+| ------------------------------ | ------- |
+| DOI                            | `doi`   |
+| Microsoft Academic Graph (MAG) | `mag`   |
+| PubMed ID (PMID)               | `pmid`  |
+| PubMed Central ID (PMCID)      | `pmcid` |
+
+\u26a0\ufe0f You must make sure that the ID(s) you supply are valid and correct. If an ID you request is incorrect, you will get no result.
+
+## Select fields
+
+You can use `select` to limit the fields that are returned in a work object:
+
+```python
+# Fetch only specific fields to reduce response size and improve performance
+minimal_work = Works().select(["id", "display_name", "cited_by_count"]).get("W2741809807")
+
+# Now only the selected fields are populated
+print(minimal_work.display_name)  # Works
+print(minimal_work.abstract)  # None (not selected)
+```

--- a/docs/works/get-lists-of-works.md
+++ b/docs/works/get-lists-of-works.md
@@ -1,0 +1,106 @@
+# Get lists of works
+
+You can get lists of works using the Python client:
+
+```python
+from openalex import Works
+
+# Create a query for all works (no filters applied)
+all_works_query = Works()
+
+# Execute the query to get the FIRST PAGE of results
+first_page = all_works_query.get()
+
+# IMPORTANT: This does NOT return all 240+ million works!
+# It returns only the first 25 works (one page)
+print(f"Total works matching query: {first_page.meta.count:,}")  # ~245,684,392
+print(f"Works in this response: {len(first_page.results)}")  # 25
+print(f"Current page: {first_page.meta.page}")  # 1
+print(f"Results per page: {first_page.meta.per_page}")  # 25
+```
+
+The response contains:
+- **meta**: Information about pagination and total results
+- **results**: List of Work objects for the current page only
+- **group_by**: Empty list (used only when grouping results)
+
+## Understanding pagination
+
+```python
+# Each result shows basic work information
+for work in first_page.results:
+    print(f"{work.display_name}")
+    print(f"  Type: {work.type}")
+    print(f"  Year: {work.publication_year}")
+    print(f"  Citations: {work.cited_by_count}")
+```
+
+## Page and sort works
+
+You can control pagination and sorting:
+
+```python
+# Get a specific page with custom page size (max 200 per page)
+page2 = Works().get(per_page=50, page=2)
+# This returns works 51-100 out of millions
+
+# Sort results by different fields
+recent_works = Works().sort(publication_year="desc").get()
+# Returns 25 most recent works
+
+highly_cited = Works().sort(cited_by_count="desc").get()
+# Returns 25 most-cited works
+
+# Combine sorting with pagination
+top_cited_page2 = (
+    Works()
+    .sort(cited_by_count="desc")
+    .get(per_page=100, page=2)
+)
+# Returns works 101-200 by citation count
+```
+
+## Sample works
+
+Get a random sample instead of paginated results:
+
+```python
+# Get 20 random works from the entire database
+random_sample = Works().sample(20).get()
+
+# Use a seed for reproducible random sampling
+reproducible_sample = Works().sample(20, seed=123).get()
+
+# Sample from filtered results
+recent_random = (
+    Works()
+    .filter(publication_year=2023)
+    .sample(10)
+    .get()
+)
+# Returns 10 random works from 2023
+```
+
+## Select fields
+
+Limit the fields returned to improve performance:
+
+```python
+# Request only specific fields for each work
+minimal_works = Works().select(["id", "display_name", "doi"]).get()
+
+# This significantly reduces response size when you don't need all fields
+for work in minimal_works.results:
+    print(work.display_name)  # Available
+    print(work.abstract)  # None - not selected
+```
+
+## Important notes on result limits
+
+1. **Default page size**: 25 results
+2. **Maximum page size**: 200 results  
+3. **Maximum offset**: 10,000 (page \u00d7 per_page must be \u2264 10,000)
+4. **For more results**: Use cursor pagination (see pagination docs)
+5. **For analytics**: Use `group_by` instead of fetching all works
+
+Continue on to learn how you can [filter](filter-works.md) and [search](search-works.md) lists of works.

--- a/docs/works/group-works.md
+++ b/docs/works/group-works.md
@@ -1,0 +1,328 @@
+# Group works
+
+You can group works to get aggregated statistics without fetching individual works:
+
+```python
+from openalex import Works
+
+# Create a query that groups works by their open access status
+oa_stats_query = Works().group_by("oa_status")
+
+# Execute the query to get COUNTS, not individual works
+oa_stats = oa_stats_query.get()
+
+# This returns aggregated statistics, NOT work objects!
+print("Open Access statistics for all works in OpenAlex:")
+for group in oa_stats.group_by:
+    # Each group has a 'key' (the OA status) and 'count'
+    print(f"  {group.key}: {group.count:,} works")
+    percentage = (group.count / oa_stats.meta.count) * 100
+    print(f"    ({percentage:.1f}% of all works)")
+```
+
+Output example:
+```
+Open Access statistics for all works in OpenAlex:
+  gold: 12,345,678 works (5.0% of all works)
+  green: 23,456,789 works (9.5% of all works)
+  hybrid: 3,456,789 works (1.4% of all works)
+  bronze: 8,901,234 works (3.6% of all works)
+  closed: 197,456,789 works (80.5% of all works)
+```
+
+\ud83d\udca1 **Key point**: `group_by()` returns COUNTS, not the actual works. This is much more efficient than trying to fetch millions of works!
+
+## Understanding group_by results
+
+```python
+# The result structure is different from regular queries
+result = Works().group_by("publication_year").get()
+
+print(result.results)  # Empty list - no individual works returned!
+print(result.group_by)  # List of groups with counts
+
+# Access the grouped data
+for group in result.group_by:
+    print(f"Year {group.key}: {group.count:,} works")
+```
+
+## Common grouping operations
+
+### Basic grouping
+
+```python
+# Group by publication year to see publication trends
+yearly_counts = Works().group_by("publication_year").get()
+# Returns ~100 groups (one per year) with counts
+
+# Group by work type to see distribution
+type_distribution = Works().group_by("type").get()
+# Shows how many articles, datasets, books, etc.
+
+# Group by language
+language_stats = Works().group_by("language").get()
+# See distribution across languages
+
+# Group by whether works are retracted
+retraction_stats = Works().group_by("is_retracted").get()
+# Usually shows ~99.9% false, ~0.1% true
+```
+
+### Open Access analysis
+
+```python
+# Analyze OA trends over time (two-dimensional grouping)
+oa_by_year = Works().group_by("publication_year", "open_access.oa_status").get()
+# Returns counts for each year-status combination
+
+# Check OA status for recent works only
+recent_oa = (
+    Works()
+    .filter(publication_year=[2020, 2021, 2022, 2023])
+    .group_by("open_access.oa_status")
+    .get()
+)
+# More focused analysis of recent OA trends
+
+# Find repositories with most OA works
+top_repositories = (
+    Works()
+    .filter(open_access={"is_oa": True})
+    .group_by("repository")
+    .get()
+)
+# Shows which repositories host the most OA content
+```
+
+### Author and institution analysis
+
+```python
+# Find most prolific authors (by author ID, not name)
+prolific_authors = Works().group_by("authorships.author.id").get()
+# Returns thousands of groups, one per author ID
+
+# Find most productive institutions
+top_institutions = Works().group_by("authorships.institutions.id").get()
+# Useful for institutional rankings
+
+# Analyze international collaboration
+countries = Works().group_by("authorships.institutions.country_code").get()
+# See research output by country
+
+# Research output by continent
+continental = Works().group_by("authorships.institutions.continent").get()
+# Broader geographic analysis
+
+# Identify Global South research
+global_south_stats = Works().group_by(
+    "authorships.institutions.is_global_south"
+).get()
+```
+
+### Publisher and source analysis
+
+```python
+# Find top publishing venues
+top_journals = Works().group_by("primary_location.source.id").get()
+# Groups by source (journal/repository) ID
+
+# Analyze by source type
+source_types = Works().group_by("primary_location.source.type").get()
+# Shows distribution: journal vs. repository vs. conference, etc.
+
+# Find major publishers
+publishers = Works().group_by(
+    "primary_location.source.publisher_lineage"
+).get()
+# Groups by publisher hierarchy
+
+# Check DOAJ coverage
+doaj_coverage = Works().group_by(
+    "primary_location.source.is_in_doaj"
+).get()
+# See how many works are in DOAJ-indexed journals
+```
+
+### Topic and field analysis
+
+```python
+# Analyze research by primary topic
+topics = Works().group_by("primary_topic.id").get()
+# Returns counts for each research topic
+
+# Broader analysis by scientific field
+fields = Works().group_by("primary_topic.field.id").get()
+# Groups into major fields like "Medicine", "Physics", etc.
+
+# Even broader - by domain
+domains = Works().group_by("primary_topic.domain.id").get()
+# Usually 4-5 major domains like "Health Sciences", "Physical Sciences"
+
+# Find interdisciplinary works (those with many topics)
+topic_counts = Works().group_by("topics_count").get()
+# Distribution of how many topics are assigned to works
+```
+
+## Combining filters with group_by
+
+Group_by becomes very powerful when combined with filters:
+
+```python
+# Analyze 2023 research by country
+research_2023_by_country = (
+    Works()
+    .filter(publication_year=2023)  # Only 2023 works
+    .group_by("authorships.institutions.country_code")
+    .get()
+)
+print(f"Research output by country in 2023:")
+for group in research_2023_by_country.group_by[:10]:  # Top 10
+    print(f"  {group.key}: {group.count:,} works")
+
+# OA adoption by institution type
+oa_by_inst_type = (
+    Works()
+    .filter(open_access={"is_oa": True})  # Only OA works
+    .group_by("authorships.institutions.type")
+    .get()
+)
+# Shows whether universities, companies, etc. publish more OA
+
+# Citation impact by OA status
+highly_cited_oa = (
+    Works()
+    .filter_gt(cited_by_count=100)  # Highly cited works only
+    .group_by("open_access.oa_status")
+    .get()
+)
+# See if OA works are more likely to be highly cited
+
+# Funding analysis
+nsf_funded_by_year = (
+    Works()
+    .filter(grants={"funder": "F4320306076"})  # NSF funded
+    .group_by("publication_year")
+    .get()
+)
+# Track NSF funding output over time
+```
+
+## Multi-dimensional grouping
+
+You can group by multiple fields (limited to 2 dimensions):
+
+```python
+# OA status by year - great for trend analysis
+oa_trends = Works().group_by(
+    "publication_year", 
+    "open_access.oa_status"
+).get()
+
+# Research types by country
+country_types = Works().group_by(
+    "authorships.institutions.country_code",
+    "type"
+).get()
+
+# Topics by institution
+inst_topics = Works().group_by(
+    "authorships.institutions.id",
+    "primary_topic.field.id"
+).get()
+```
+
+## Sorting grouped results
+
+Control how results are ordered:
+
+```python
+# Default: sorted by count (descending)
+default_sort = Works().group_by("type").get()
+# Articles first (most common), then books, etc.
+
+# Sort by key instead of count
+alphabetical = Works().group_by("type").sort(key="asc").get()
+# article, book, chapter, dataset...
+
+# Sort by count ascending (least common first)
+rare_first = Works().group_by("type").sort(count="asc").get()
+# Rarest types appear first
+```
+
+## Practical examples
+
+### Example 1: Analyze your institution's research
+
+```python
+# First, find your institution ID
+from openalex import Institutions
+inst = Institutions().search("Stanford University").get().results[0]
+
+# Analyze research output
+stanford_analysis = (
+    Works()
+    .filter(authorships={"institutions": {"id": inst.id}})
+    .group_by("publication_year")
+    .get()
+)
+
+# OA adoption at Stanford
+stanford_oa = (
+    Works()
+    .filter(authorships={"institutions": {"id": inst.id}})
+    .filter(publication_year=[2020, 2021, 2022, 2023])
+    .group_by("open_access.oa_status")
+    .get()
+)
+```
+
+### Example 2: Journal analysis
+
+```python
+# Analyze a specific journal
+nature_stats = (
+    Works()
+    .filter(primary_location={"source": {"id": "S137773608"}})  # Nature
+    .group_by("publication_year")
+    .get()
+)
+
+# Topic distribution in Nature
+nature_topics = (
+    Works()
+    .filter(primary_location={"source": {"id": "S137773608"}})
+    .group_by("primary_topic.field.display_name")
+    .get()
+)
+```
+
+### Example 3: Research trends
+
+```python
+# Track AI/ML research growth
+ml_trend = (
+    Works()
+    .filter(primary_topic={"id": "T10159"})  # Machine Learning topic
+    .group_by("publication_year")
+    .get()
+)
+
+# Geographic distribution of ML research
+ml_geography = (
+    Works()
+    .filter(primary_topic={"id": "T10159"})
+    .filter(publication_year=2023)
+    .group_by("authorships.institutions.country_code")
+    .get()
+)
+```
+
+## Important notes
+
+1. **No individual works returned**: `group_by()` only returns counts
+2. **Maximum 10,000 groups**: API limit on number of groups returned
+3. **Two dimensions maximum**: Can group by at most 2 fields
+4. **Efficient for analytics**: Much faster than fetching all works
+5. **Can't access work details**: Only counts and group keys available
+
+When you need statistics, always prefer `group_by()` over trying to fetch and count individual works!

--- a/docs/works/search-works.md
+++ b/docs/works/search-works.md
@@ -1,0 +1,223 @@
+# Search works
+
+The best way to search for works is to use the `search` method, which searches across titles, abstracts, and fulltext:
+
+```python
+from openalex import Works
+
+# Create a search query for works mentioning "dna"
+dna_search = Works().search("dna")
+
+# Execute to get the first page of results (25 works)
+results = dna_search.get()
+
+print(f"Total works matching 'dna': {results.meta.count:,}")  # e.g., 3,456,789
+print(f"Showing first {len(results.results)} results")  # 25
+
+# Results are ranked by relevance
+for i, work in enumerate(results.results[:5], 1):
+    print(f"{i}. {work.display_name}")
+    print(f"   Relevance score: {work.relevance_score}")
+```
+
+Fulltext search is available for a subset of works, see `Work.has_fulltext` for more details.
+
+\ud83d\udca1 Search uses relevance ranking, stemming (e.g., "running" matches "run"), and removes common words.
+
+## Search a specific field
+
+You can search within specific fields for more precise results:
+
+```python
+# Search only in titles
+cubist_titles = Works().search_filter(title="cubist").get()
+# Finds works with "cubist" in the title field only
+
+# Search only in abstracts  
+ai_abstracts = Works().search_filter(
+    abstract="artificial intelligence"
+).get()
+# More specific than general search
+
+# Search in fulltext (when available)
+climate_fulltext = Works().search_filter(
+    fulltext="climate change mitigation strategies"
+).get()
+# Searches the complete text of works where we have it
+
+# Search in author affiliation strings
+sfu_affiliations = Works().search_filter(
+    raw_affiliation_strings="Simon Fraser University"
+).get()
+# Finds works where author affiliations mention SFU
+
+# Search in both title and abstract
+quantum_papers = Works().search_filter(
+    title_and_abstract="quantum computing"
+).get()
+# Searches both fields simultaneously
+```
+
+The following fields can be searched:
+
+| Search filter | Field that is searched | Python method |
+|---------------|------------------------|---------------|
+| `abstract.search` | `abstract_inverted_index` | `.search_filter(abstract="...")` |
+| `display_name.search` | `display_name` | `.search_filter(display_name="...")` |
+| `fulltext.search` | fulltext via n-grams | `.search_filter(fulltext="...")` |
+| `raw_affiliation_strings.search` | `authorships.raw_affiliation_strings` | `.search_filter(raw_affiliation_strings="...")` |
+| `title.search` | `display_name` | `.search_filter(title="...")` |
+| `title_and_abstract.search` | `display_name` and `abstract_inverted_index` | `.search_filter(title_and_abstract="...")` |
+
+## Default search vs field search
+
+```python
+# Option 1: General search (searches title, abstract, fulltext)
+general_search = Works().search("machine learning").get()
+
+# Option 2: Field-specific search using filter
+title_only = Works().filter(
+    default={"search": "machine learning"}
+).get()
+
+# Option 3: Multiple field searches
+specific_search = Works().search_filter(
+    title="neural networks",
+    abstract="deep learning"
+).get()
+# Must match "neural networks" in title AND "deep learning" in abstract
+```
+
+## Combining search with filters
+
+Search is most powerful when combined with filters:
+
+```python
+# Find recent, highly-cited ML papers
+recent_ml_papers = (
+    Works()
+    .search("machine learning")  # Full-text search
+    .filter(publication_year=2023)  # Published in 2023
+    .filter(open_access={"is_oa": True})  # Open access only
+    .filter_gt(cited_by_count=10)  # More than 10 citations already
+    .sort(cited_by_count="desc")  # Most cited first
+    .get(per_page=100)  # Get top 100
+)
+
+print(f"Found {results.meta.count} highly-cited 2023 ML papers")
+
+# Search specific fields with additional filters  
+quantum_2023 = (
+    Works()
+    .search_filter(title="quantum computing")  # Title must contain this
+    .filter(publication_year=2023)
+    .filter_gt(cited_by_count=5)
+    .get()
+)
+
+# Complex query: Find review articles on climate change
+climate_reviews = (
+    Works()
+    .search_filter(
+        title="climate change",
+        abstract="systematic review"
+    )
+    .filter(type="article")
+    .filter(from_publication_date="2020-01-01")
+    .get()
+)
+```
+
+## Why can't I search by name of related entity?
+
+You cannot directly search for author names, institution names, etc. in work queries. Instead, use a two-step process:
+
+```python
+from openalex import Institutions, Authors, Works
+
+# Step 1: Find the institution by name
+institutions = Institutions().search("NYU").get()
+nyu = institutions.results[0]
+print(f"Found: {nyu.display_name} ({nyu.id})")  # New York University (I57206974)
+
+# Step 2: Find works from that institution
+nyu_works = Works().filter(
+    authorships={"institutions": {"id": nyu.id}}
+).get()
+print(f"NYU has {nyu_works.meta.count:,} works")
+
+# Similarly for authors
+authors = Authors().search("John Smith").get()
+if authors.results:
+    author = authors.results[0]
+    author_works = Works().filter(
+        authorships={"author": {"id": author.id}}
+    ).get()
+```
+
+Why? Because:
+- "NYU" might miss "New York University" 
+- "J. Smith" might miss "John Smith"
+- Multiple people might have the same name
+
+We've already resolved these ambiguities in our entity records!
+
+## Autocomplete works
+
+Create a fast type-ahead search experience:
+
+```python
+# Get autocomplete suggestions for works
+suggestions = Works().autocomplete("quantum comp")
+
+# Returns fast, lightweight results
+for work in suggestions.results:
+    print(f"{work.display_name}")
+    print(f"  Authors: {work.hint}")  # Hint shows authors
+    print(f"  Citations: {work.cited_by_count}")
+    print(f"  Work ID: {work.id}")
+    print()
+```
+
+Example output:
+```
+Quantum computation and quantum information
+  Authors: Michael A. Nielsen, Isaac L. Chuang  
+  Citations: 12453
+  Work ID: https://openalex.org/W1234567
+
+Quantum Computing: An Applied Approach
+  Authors: Jack D. Hidary
+  Citations: 234
+  Work ID: https://openalex.org/W2234567
+```
+
+## Search tips
+
+1. **Use filters to narrow results**: Pure search might return millions of results
+2. **Be specific with field search**: `search_filter(title=...)` is more precise than `search()`
+3. **Check fulltext availability**: Not all works have fulltext indexed
+4. **Combine strategies**: Use search for discovery, then filters for precision
+
+```python
+# Good: Specific search with reasonable result size
+good_query = (
+    Works()
+    .search("climate change")
+    .filter(publication_year=[2022, 2023])
+    .filter(type="article")
+    .filter_gt(cited_by_count=5)
+    .get()
+)
+
+# Less ideal: Too broad
+broad_query = Works().search("science").get()  # Millions of results!
+
+# Better: Add context
+better_query = (
+    Works()
+    .search("citizen science")
+    .filter(primary_topic={"field": {"display_name": "Environmental Science"}})
+    .get()
+)
+```

--- a/docs/works/work-object.md
+++ b/docs/works/work-object.md
@@ -1,0 +1,361 @@
+# Work object
+
+When you fetch a work using the Python client, you get a `Work` object with all of OpenAlex's data about that work. Here's how to access the various properties:
+
+```python
+from openalex import Works
+
+# Get a specific work
+work = Works()["W2741809807"]
+
+# The work object has all the data as Python attributes
+print(type(work))  # <class 'openalex.models.work.Work'>
+```
+
+## Basic properties
+
+```python
+# Identifiers
+print(work.id)  # "https://openalex.org/W2741809807"
+print(work.doi)  # "https://doi.org/10.7717/peerj.4375"
+
+# Title and display name (these are the same)
+print(work.title)  # "The state of OA: a large-scale analysis..."
+print(work.display_name)  # Same as title
+
+# Publication info
+print(work.publication_year)  # 2018
+print(work.publication_date)  # "2018-02-13"
+print(work.type)  # "article"
+print(work.type_crossref)  # "journal-article" (legacy format)
+
+# Basic metadata
+print(work.language)  # "en"
+print(work.created_date)  # "2017-08-08"
+print(work.updated_date)  # "2024-01-01T00:00:00.000000"
+
+# Quality flags
+print(work.is_paratext)  # False (True for editorials, TOCs, etc.)
+print(work.is_retracted)  # False (True if retracted)
+```
+
+## Abstract
+
+The abstract is stored as an inverted index (word positions), but the Python client provides automatic conversion:
+
+```python
+# Get abstract as plain text (automatically converted)
+if work.abstract:
+    print(work.abstract[:200] + "...")
+    # "Despite growing interest in Open Access (OA), relatively little is known..."
+
+# Access the raw inverted index if needed
+if work.abstract_inverted_index:
+    print(list(work.abstract_inverted_index.keys())[:10])
+    # ['Despite', 'growing', 'interest', 'in', 'Open', 'Access', ...]
+```
+
+## Authorships
+
+Authorships contain author and affiliation information:
+
+```python
+# Iterate through all authors
+print(f"This work has {len(work.authorships)} authors")
+
+for authorship in work.authorships:
+    # Author information
+    author = authorship.author
+    print(f"\nAuthor: {author.display_name}")
+    if author.orcid:
+        print(f"  ORCID: {author.orcid}")
+    
+    # Author position in the paper
+    print(f"  Position: {authorship.author_position}")  # "first", "middle", or "last"
+    print(f"  Corresponding: {authorship.is_corresponding}")
+    
+    # Institutional affiliations
+    for institution in authorship.institutions:
+        print(f"  Institution: {institution.display_name}")
+        print(f"    Country: {institution.country_code}")
+        print(f"    Type: {institution.type}")  # "education", "company", etc.
+        print(f"    ROR: {institution.ror}")
+    
+    # Raw affiliation strings (as they appear in the paper)
+    for affiliation in authorship.affiliations:
+        print(f"  Raw text: '{affiliation.raw_affiliation_string}'")
+        print(f"    Matched to: {affiliation.institution_ids}")
+    
+    # Countries (derived from institutions and raw strings)
+    if authorship.countries:
+        print(f"  Countries: {', '.join(authorship.countries)}")
+```
+
+## Locations (where to find the work)
+
+Works can be found in multiple locations (journal, repositories, etc.):
+
+```python
+# Primary location (usually the publisher's version)
+primary = work.primary_location
+if primary:
+    print(f"Primary location: {primary.source.display_name}")
+    print(f"  Type: {primary.source.type}")  # "journal", "repository", etc.
+    print(f"  Version: {primary.version}")  # "publishedVersion", "acceptedVersion", etc.
+    print(f"  License: {primary.license}")  # "cc-by", etc.
+    print(f"  Open Access: {primary.is_oa}")
+    print(f"  URL: {primary.landing_page_url}")
+    if primary.pdf_url:
+        print(f"  PDF: {primary.pdf_url}")
+
+# Best open access location
+if work.best_oa_location:
+    print(f"\nBest OA location: {work.best_oa_location.source.display_name}")
+    print(f"  URL: {work.best_oa_location.landing_page_url}")
+
+# All locations (including repositories, preprint servers, etc.)
+print(f"\nFound in {work.locations_count} locations total:")
+for i, location in enumerate(work.locations, 1):
+    print(f"{i}. {location.source.display_name}")
+    print(f"   Version: {location.version}, OA: {location.is_oa}")
+```
+
+## Open Access information
+
+```python
+# Comprehensive OA information
+oa = work.open_access
+print(f"Open Access: {oa.is_oa}")
+print(f"OA Status: {oa.oa_status}")  
+# Possible values: "gold", "green", "hybrid", "bronze", "closed"
+
+if oa.oa_url:
+    print(f"Free to read at: {oa.oa_url}")
+
+print(f"Available in repository: {oa.any_repository_has_fulltext}")
+
+# For detailed OA analysis, check locations
+gold_oa = any(loc.is_oa and loc.source.type == "journal" 
+              for loc in work.locations)
+green_oa = any(loc.is_oa and loc.source.type == "repository" 
+               for loc in work.locations)
+```
+
+## Citations and references
+
+```python
+# Citation count
+print(f"Cited by {work.cited_by_count:,} other works")
+
+# URL to get works that cite this one
+print(f"Citing works API: {work.cited_by_api_url}")
+
+# To actually get citing works:
+citing = Works().filter(cites=work.id).get()
+print(f"Recent citations: {len(citing.results)}")
+
+# References (works this paper cites)
+print(f"\nThis work references {len(work.referenced_works)} other works")
+# Show first 5 references
+for ref_id in work.referenced_works[:5]:
+    print(f"  \u2192 {ref_id}")
+
+# Related works (algorithmically determined)
+print(f"\n{len(work.related_works)} related works identified")
+for related_id in work.related_works[:3]:
+    print(f"  \u2194 {related_id}")
+
+# Citation trend by year
+print("\nCitations by year:")
+for count in work.counts_by_year:
+    print(f"  {count.year}: {count.cited_by_count}")
+```
+
+## Topics and research areas
+
+```python
+# Primary topic (most relevant)
+if work.primary_topic:
+    topic = work.primary_topic
+    print(f"Primary research topic: {topic.display_name}")
+    print(f"  Relevance score: {topic.score:.3f}")
+    print(f"  Subfield: {topic.subfield.display_name}")
+    print(f"  Field: {topic.field.display_name}")
+    print(f"  Domain: {topic.domain.display_name}")
+
+# All topics (up to 3)
+print(f"\nAll {len(work.topics)} topics:")
+for topic in work.topics:
+    print(f"  \u2022 {topic.display_name} (score: {topic.score:.3f})")
+
+# Keywords extracted from the work
+if work.keywords:
+    print(f"\nKeywords:")
+    for kw in work.keywords:
+        print(f"  \u2022 {kw.display_name} (score: {kw.score:.3f})")
+
+# Sustainable Development Goals relevance
+if work.sustainable_development_goals:
+    print(f"\nRelevant to SDGs:")
+    for sdg in work.sustainable_development_goals:
+        print(f"  \u2022 {sdg.display_name} (score: {sdg.score:.3f})")
+
+# Legacy concepts (being phased out)
+print(f"\n{len(work.concepts)} concepts assigned")
+for concept in work.concepts[:5]:
+    print(f"  \u2022 {concept.display_name} (score: {concept.score:.3f})")
+```
+
+## Bibliographic information
+
+```python
+# Traditional bibliographic metadata
+if work.biblio:
+    print(f"Volume: {work.biblio.volume}")
+    print(f"Issue: {work.biblio.issue}")
+    print(f"Pages: {work.biblio.first_page}-{work.biblio.last_page}")
+
+# Note: These are strings because values like "Spring" or "Supplement 1" exist
+```
+
+## All identifiers
+
+```python
+# Access all known identifiers
+ids = work.ids
+print(f"OpenAlex ID: {ids.openalex}")
+print(f"DOI: {ids.doi}")
+if ids.pmid:
+    print(f"PubMed ID: {ids.pmid}")
+if ids.pmcid:
+    print(f"PubMed Central ID: {ids.pmcid}")
+if ids.mag:
+    print(f"Microsoft Academic ID: {ids.mag}")
+
+# Check which indexes include this work
+print(f"Indexed in: {', '.join(work.indexed_in)}")
+# e.g., ["crossref", "pubmed"]
+```
+
+## Funding information
+
+```python
+# Grant funding
+if work.grants:
+    print(f"Funded by {len(work.grants)} grants:")
+    for grant in work.grants:
+        print(f"  \u2022 {grant.funder_display_name}")
+        if grant.award_id:
+            print(f"    Award: {grant.award_id}")
+```
+
+## Article Processing Charges (APC)
+
+```python
+# List price for publishing
+if work.apc_list:
+    apc = work.apc_list
+    print(f"APC list price: {apc.value} {apc.currency}")
+    print(f"  (${apc.value_usd} USD)")
+    print(f"  Source: {apc.provenance}")
+
+# What was actually paid
+if work.apc_paid:
+    paid = work.apc_paid
+    print(f"APC actually paid: {paid.value} {paid.currency}")
+    print(f"  (${paid.value_usd} USD)")
+    print(f"  Source: {paid.provenance}")
+```
+
+## Additional metadata
+
+```python
+# MeSH terms (for biomedical works from PubMed)
+if work.mesh:
+    print("MeSH terms:")
+    for mesh in work.mesh:
+        print(f"  \u2022 {mesh.descriptor_name}")
+        if mesh.qualifier_name:
+            print(f"    Qualifier: {mesh.qualifier_name}")
+        print(f"    Major topic: {mesh.is_major_topic}")
+
+# Full-text availability
+print(f"Has indexed fulltext: {work.has_fulltext}")
+if work.has_fulltext:
+    print(f"Fulltext source: {work.fulltext_origin}")  # "pdf" or "ngrams"
+
+# Collaboration metrics
+print(f"Distinct institutions: {work.institutions_distinct_count}")
+print(f"Distinct countries: {work.countries_distinct_count}")
+
+# Corresponding author details
+if work.corresponding_author_ids:
+    print(f"Corresponding authors: {work.corresponding_author_ids}")
+if work.corresponding_institution_ids:
+    print(f"Corresponding institutions: {work.corresponding_institution_ids}")
+
+# Advanced citation metrics (when available)
+if work.fwci is not None:
+    print(f"Field-Weighted Citation Impact: {work.fwci:.2f}")
+    
+if work.citation_normalized_percentile:
+    cnp = work.citation_normalized_percentile
+    print(f"Citation percentile: {cnp.value:.1%}")
+    print(f"  In top 1%: {cnp.is_in_top_1_percent}")
+    print(f"  In top 10%: {cnp.is_in_top_10_percent}")
+```
+
+## Convenience methods and properties
+
+The Work object includes helpful computed properties:
+
+```python
+# Abstract as text (mentioned earlier)
+abstract_text = work.abstract  # Automatically converted from inverted index
+
+# Check data availability
+has_authors = len(work.authorships) > 0
+has_references = len(work.referenced_works) > 0
+has_fulltext = work.has_fulltext
+
+# Safe access patterns for nested data
+# Get first author name (safely)
+first_author_name = None
+if work.authorships and work.authorships[0].author:
+    first_author_name = work.authorships[0].author.display_name
+
+# Get primary source name (safely)
+source_name = None
+if work.primary_location and work.primary_location.source:
+    source_name = work.primary_location.source.display_name
+
+# Count authors from specific country
+us_authors = sum(
+    1 for authorship in work.authorships
+    if "US" in (authorship.countries or [])
+)
+```
+
+## Working with None values
+
+Many fields can be None, so always check:
+
+```python
+# Safe patterns for optional fields
+if work.abstract:
+    process_abstract(work.abstract)
+
+if work.primary_location:
+    source = work.primary_location.source
+    if source:
+        print(source.display_name)
+
+# Or use Python's optional chaining (3.8+)
+source_name = work.primary_location.source.display_name if work.primary_location and work.primary_location.source else None
+
+# For lists, check if they exist and have content
+if work.authorships:
+    for authorship in work.authorships:
+        # Process each author
+        pass
+```


### PR DESCRIPTION
## Summary
- add new docs in `docs/works/` explaining how to access works using the python client
- provide examples for getting a single work, listing works, filtering, searching and grouping
- document the Work object fields and usage

## Testing
- `pip install -r requirements-dev.txt` *(fails: dependency resolution conflict)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68484a6b9b6c832ba1d9d138efd86fb4