### PR TITLE
Add Python client based publisher docs

### DIFF
--- a/docs/publishers/README.md
+++ b/docs/publishers/README.md
@@ -1,0 +1,42 @@
+---
+description: Companies and organizations that distribute works
+---
+
+# \ud83c\udfe2 Publishers
+
+Publishers are companies and organizations that distribute journal articles, books, and theses. OpenAlex indexes about 10,000 publishers. You can access publishers in the Python client like this:
+
+```python
+from openalex import Publishers
+
+# Create a query builder for publishers
+publishers_query = Publishers()
+
+# Execute the query to get the first page of results (25 publishers by default)
+first_page = publishers_query.get()
+
+print(f"Total publishers in OpenAlex: {first_page.meta.count:,}")  # ~10,000
+print(f"Publishers returned in this page: {len(first_page.results)}")  # 25
+```
+
+Our publisher data is closely tied to the publisher information in Wikidata. So the [Canonical External ID](../../how-to-use-the-api/get-single-entities/#canonical-external-ids) for OpenAlex publishers is a Wikidata ID, and almost every publisher has one. Publishers are linked to sources through the `host_organization` field.
+
+## Important: Understanding Query Results
+
+When you use `Publishers()`, you're creating a **query builder**, not fetching data. The data is only retrieved when you call:
+- `.get()` - Returns one page of results (25-200 items)
+- `.paginate()` - Returns an iterator for all results
+- `.group_by(...).get()` - Returns aggregated counts, not individual publishers
+
+With only ~10,000 publishers total, it's actually feasible to fetch all publishers if needed (unlike works or authors).
+
+## What's next
+
+Learn more about what you can do with publishers:
+
+* [The Publisher object](publisher-object.md)
+* [Get a single publisher](get-a-single-publisher.md)
+* [Get lists of publishers](get-lists-of-publishers.md)
+* [Filter publishers](filter-publishers.md)
+* [Search publishers](search-publishers.md)
+* [Group publishers](group-publishers.md)

--- a/docs/publishers/filter-publishers.md
+++ b/docs/publishers/filter-publishers.md
@@ -1,0 +1,271 @@
+# Filter publishers
+
+You can filter publishers using the Python client:
+
+```python
+from openalex import Publishers
+
+# Create a filtered query for top-level publishers
+parent_publishers_query = Publishers().filter(hierarchy_level=0)
+
+# Execute the query to get the first page of results
+results = parent_publishers_query.get()
+
+print(f"Total parent publishers: {results.meta.count}")
+print(f"Showing first {len(results.results)} publishers")
+
+# Show some examples
+for pub in results.results[:5]:
+    print(f"- {pub.display_name}")
+```
+
+\ud83d\udca1 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+
+## Publishers attribute filters
+
+You can filter using these attributes of the [`Publisher`](publisher-object.md) object:
+
+### Basic attribute filters
+
+```python
+# Filter by cited_by_count
+highly_cited = Publishers().filter(cited_by_count=1000000).get()  # Exactly 1M
+very_highly_cited = Publishers().filter_gt(cited_by_count=10000000).get()  # More than 10M
+
+# Filter by works_count
+large_publishers = Publishers().filter_gt(works_count=100000).get()  # More than 100k works
+small_publishers = Publishers().filter_lt(works_count=1000).get()  # Fewer than 1k works
+
+# Filter by hierarchy level
+parent_publishers = Publishers().filter(hierarchy_level=0).get()  # Top level only
+child_publishers = Publishers().filter(hierarchy_level=1).get()  # One level down
+deep_subsidiaries = Publishers().filter_gt(hierarchy_level=1).get()  # Two+ levels down
+
+# Filter by specific publisher ID
+specific_ids = Publishers().filter(
+    openalex=["P4310319965", "P4310320990"]
+).get()
+```
+
+### Geographic filters
+
+```python
+# Filter by country
+us_publishers = Publishers().filter(country_codes="US").get()
+uk_publishers = Publishers().filter(country_codes="GB").get()
+
+# Multiple countries (OR operation)
+european_publishers = Publishers().filter(
+    country_codes=["DE", "FR", "IT", "ES", "NL"]
+).get()
+```
+
+### Hierarchy filters
+
+```python
+# Find all subsidiaries of a publisher using lineage
+springer_nature_id = "P4310319965"
+springer_family = Publishers().filter(lineage=springer_nature_id).get()
+# This includes Springer Nature and all its children
+
+# Find direct children only
+direct_children = Publishers().filter(parent_publisher=springer_nature_id).get()
+
+# Find publishers with a specific ROR
+ror_publisher = Publishers().filter(ror="https://ror.org/02scfj030").get()
+
+# Find publishers with a specific Wikidata ID
+wikidata_publisher = Publishers().filter(wikidata="Q746413").get()
+```
+
+### Summary statistics filters
+
+```python
+# Filter by h-index
+high_impact = Publishers().filter_gt(summary_stats={"h_index": 500}).get()
+
+# Filter by i10-index
+very_productive = Publishers().filter_gt(summary_stats={"i10_index": 10000}).get()
+
+# Filter by 2-year mean citedness (impact factor equivalent)
+high_quality = Publishers().filter_gt(
+    summary_stats={"2yr_mean_citedness": 5.0}
+).get()
+
+# Combine metrics
+elite_publishers = (
+    Publishers()
+    .filter_gt(summary_stats={"h_index": 300})
+    .filter_gt(summary_stats={"i10_index": 50000})
+    .filter_gt(works_count=100000)
+    .get()
+)
+```
+
+## Convenience filters
+
+These filters aren't attributes of the Publisher object, but they're handy for common use cases:
+
+### Geographic convenience filters
+
+```python
+# Filter by continent
+european_publishers = Publishers().filter(continent="europe").get()
+asian_publishers = Publishers().filter(continent="asia").get()
+```
+
+### Text search filters
+
+```python
+# Search in display names
+elsevier_search = Publishers().filter(
+    display_name={"search": "elsevier"}
+).get()
+
+# Alternative: use search_filter
+springer_search = Publishers().search_filter(display_name="springer").get()
+
+# Default search (same as using .search() method)
+default_search = Publishers().filter(
+    default={"search": "university press"}
+).get()
+```
+
+## Complex filtering
+
+### Combining filters (AND operations)
+
+```python
+# Large US publishers
+large_us_publishers = (
+    Publishers()
+    .filter(country_codes="US")
+    .filter_gt(works_count=50000)
+    .filter(hierarchy_level=0)  # Parent companies only
+    .get()
+)
+
+# High-impact European publishers
+european_elite = (
+    Publishers()
+    .filter(continent="europe")
+    .filter_gt(summary_stats={"h_index": 200})
+    .filter_gt(cited_by_count=1000000)
+    .get()
+)
+```
+
+### NOT operations
+
+```python
+# Publishers NOT from the US
+non_us_publishers = Publishers().filter_not(country_codes="US").get()
+
+# Non-parent publishers (subsidiaries only)
+subsidiaries = Publishers().filter_not(hierarchy_level=0).get()
+```
+
+### Range queries
+
+```python
+# Mid-size publishers (10k-100k works)
+mid_size = (
+    Publishers()
+    .filter_gt(works_count=10000)
+    .filter_lt(works_count=100000)
+    .get()
+)
+
+# Publishers with moderate citation impact
+moderate_impact = (
+    Publishers()
+    .filter_gt(cited_by_count=100000)
+    .filter_lt(cited_by_count=1000000)
+    .get()
+)
+```
+
+## Practical examples
+
+### Example 1: Analyze publisher families
+
+```python
+# Get a major publisher
+elsevier = Publishers().search("Elsevier BV").get().results[0]
+
+# Find all entities in the Elsevier family
+elsevier_family = Publishers().filter(lineage=elsevier.id).get()
+print(f"Elsevier family has {elsevier_family.meta.count} entities")
+
+# Show the hierarchy
+for pub in elsevier_family.results:
+    indent = "  " * pub.hierarchy_level
+    print(f"{indent}{pub.display_name} (Level {pub.hierarchy_level})")
+```
+
+### Example 2: Compare publishers by region
+
+```python
+# Get top publishers by continent
+def top_publishers_by_continent(continent, limit=5):
+    return (
+        Publishers()
+        .filter(continent=continent)
+        .sort(works_count="desc")
+        .get(per_page=limit)
+    )
+
+# Compare different regions
+for continent in ["north_america", "europe", "asia"]:
+    top_pubs = top_publishers_by_continent(continent)
+    print(f"\nTop {continent.title()} publishers:")
+    for pub in top_pubs.results:
+        print(f"  {pub.display_name}: {pub.works_count:,} works")
+```
+
+### Example 3: Find university presses
+
+```python
+# University presses often have "University Press" in the name
+uni_presses = Publishers().search("University Press").get(per_page=50)
+
+print(f"Found {uni_presses.meta.count} university presses")
+
+# Analyze their characteristics
+total_works = sum(p.works_count for p in uni_presses.results)
+avg_works = total_works / len(uni_presses.results)
+print(f"Average works per university press: {avg_works:,.0f}")
+
+# Find the largest university presses
+largest_uni_presses = (
+    Publishers()
+    .search("University Press")
+    .sort(works_count="desc")
+    .get(per_page=10)
+)
+```
+
+## Performance tips
+
+Since there are only ~10,000 publishers:
+
+1. **Pagination is feasible**: You can actually fetch all publishers if needed
+2. **Less need for select()**: Response sizes are manageable
+3. **Group by is still useful**: For analytics without fetching details
+4. **Hierarchy matters**: Use `lineage` to get entire publisher families efficiently
+
+```python
+# Example: Get summary of all publishers efficiently
+def get_publisher_summary():
+    # Use group_by for statistics
+    by_country = Publishers().group_by("country_codes").get()
+    by_level = Publishers().group_by("hierarchy_level").get()
+    
+    print("Publishers by country (top 10):")
+    for group in by_country.group_by[:10]:
+        print(f"  {group.key}: {group.count}")
+    
+    print("\nPublishers by hierarchy level:")
+    for group in by_level.group_by:
+        print(f"  Level {group.key}: {group.count}")
+```

--- a/docs/publishers/get-a-single-publisher.md
+++ b/docs/publishers/get-a-single-publisher.md
@@ -1,0 +1,72 @@
+# Get a single publisher
+
+It's easy to get a publisher using the Python client:
+
+```python
+from openalex import Publishers
+
+# Get a specific publisher by their OpenAlex ID
+publisher = Publishers()["P4310319965"]
+
+# Alternative syntax using the get method
+publisher = Publishers().get("P4310319965")
+```
+
+That will return a [`Publisher`](publisher-object.md) object, describing everything OpenAlex knows about the publisher with that ID:
+
+```python
+# Access publisher properties directly as Python attributes
+print(publisher.id)  # "https://openalex.org/P4310319965"
+print(publisher.display_name)  # "Springer Nature"
+print(publisher.alternate_titles)  # List of alternate names
+print(publisher.hierarchy_level)  # 0 (top-level publisher)
+print(publisher.works_count)  # Number of works published
+print(publisher.cited_by_count)  # Total citations to their works
+```
+
+You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
+
+```python
+# Fetch multiple specific publishers in one API call
+publisher_ids = ["P4310319965", "P4310320990", "P4310319900"]
+multiple_publishers = Publishers().filter(openalex=publisher_ids).get()
+
+print(f"Found {len(multiple_publishers.results)} publishers")
+for pub in multiple_publishers.results:
+    print(f"- {pub.display_name} ({pub.works_count:,} works)")
+```
+
+## External IDs
+
+You can look up publishers using external IDs such as a Wikidata ID:
+
+```python
+# Get publisher by Wikidata ID
+publisher = Publishers()["wikidata:Q1479654"]
+
+# Get publisher by ROR ID
+publisher = Publishers()["ror:https://ror.org/02scfj030"]
+
+# Direct lookup by full URL also works
+publisher = Publishers()["https://www.wikidata.org/entity/Q746413"]
+```
+
+Available external IDs for publishers are:
+
+| External ID | URN | Example |
+|------------|-----|---------|
+| ROR | `ror` | `ror:02scfj030` |
+| Wikidata | `wikidata` | `wikidata:Q746413` |
+
+## Select fields
+
+You can use `select` to limit the fields that are returned in a publisher object:
+
+```python
+# Fetch only specific fields to reduce response size
+minimal_publisher = Publishers().select(["id", "display_name", "works_count"]).get("P4310319965")
+
+# Now only the selected fields are populated
+print(minimal_publisher.display_name)  # Works
+print(minimal_publisher.cited_by_count)  # None (not selected)
+```

--- a/docs/publishers/get-lists-of-publishers.md
+++ b/docs/publishers/get-lists-of-publishers.md
@@ -1,0 +1,119 @@
+# Get lists of publishers
+
+You can get lists of publishers using the Python client:
+
+```python
+from openalex import Publishers
+
+# Create a query for all publishers (no filters applied)
+all_publishers_query = Publishers()
+
+# Execute the query to get the FIRST PAGE of results
+first_page = all_publishers_query.get()
+
+# Note: With ~10,000 total publishers, this is actually manageable
+# unlike works (240M+) or authors (93M+)
+print(f"Total publishers: {first_page.meta.count:,}")  # ~10,000
+print(f"Publishers in this response: {len(first_page.results)}")  # 25
+print(f"Current page: {first_page.meta.page}")  # 1
+```
+
+The response contains:
+- **meta**: Information about pagination and total results
+- **results**: List of Publisher objects for the current page
+- **group_by**: Empty list (used only when grouping results)
+
+## Understanding the results
+
+```python
+# Each result shows publisher information
+for publisher in first_page.results[:5]:  # First 5 publishers
+    print(f"\n{publisher.display_name}")
+    print(f"  ID: {publisher.id}")
+    print(f"  Works: {publisher.works_count:,}")
+    print(f"  Citations: {publisher.cited_by_count:,}")
+    print(f"  Hierarchy: Level {publisher.hierarchy_level}")
+    if publisher.country_codes:
+        print(f"  Countries: {', '.join(publisher.country_codes)}")
+```
+
+## Page and sort publishers
+
+You can control pagination and sorting:
+
+```python
+# Get a specific page with custom page size
+page2 = Publishers().get(per_page=50, page=2)
+# This returns publishers 51-100
+
+# Sort by different fields
+# Largest publishers by work count
+largest_publishers = Publishers().sort(works_count="desc").get()
+
+# Most cited publishers
+most_cited = Publishers().sort(cited_by_count="desc").get()
+
+# Alphabetical by name
+alphabetical = Publishers().sort(display_name="asc").get()
+
+# Get ALL publishers (feasible with only ~10,000)
+# This will make about 50 API calls
+all_publishers = []
+for publisher in Publishers().paginate(per_page=200):
+    all_publishers.append(publisher)
+print(f"Fetched all {len(all_publishers)} publishers")
+```
+
+## Sample publishers
+
+Get a random sample of publishers:
+
+```python
+# Get 10 random publishers
+random_sample = Publishers().sample(10).get()
+
+# Use a seed for reproducible random sampling
+reproducible_sample = Publishers().sample(10, seed=42).get()
+
+# Sample from filtered results
+top_level_sample = (
+    Publishers()
+    .filter(hierarchy_level=0)  # Only parent publishers
+    .sample(5)
+    .get()
+)
+```
+
+## Select fields
+
+Limit the fields returned to improve performance:
+
+```python
+# Request only specific fields
+minimal_publishers = Publishers().select([
+    "id", 
+    "display_name", 
+    "alternate_titles"
+]).get()
+
+# This reduces response size significantly
+for publisher in minimal_publishers.results:
+    print(publisher.display_name)  # Available
+    print(publisher.works_count)  # None - not selected
+```
+
+## Practical example: Publisher hierarchy
+
+```python
+# Get all top-level publishers
+parent_publishers = Publishers().filter(hierarchy_level=0).get()
+print(f"Found {parent_publishers.meta.count} parent publishers")
+
+# For each parent, you could get their children
+for parent in parent_publishers.results[:5]:
+    # Get publishers that have this one as parent
+    children = Publishers().filter(parent_publisher=parent.id).get()
+    print(f"\n{parent.display_name} has {children.meta.count} subsidiaries")
+```
+
+Continue on to learn how you can [filter](filter-publishers.md) and [search](search-publishers.md) lists of publishers.

--- a/docs/publishers/group-publishers.md
+++ b/docs/publishers/group-publishers.md
@@ -1,0 +1,258 @@
+# Group publishers
+
+You can group publishers to get aggregated statistics without fetching individual publisher records:
+
+```python
+from openalex import Publishers
+
+# Create a query that groups publishers by country
+country_stats_query = Publishers().group_by("country_codes")
+
+# Execute the query to get COUNTS, not individual publishers
+country_stats = country_stats_query.get()
+
+# This returns aggregated statistics, NOT publisher objects!
+print("Publishers by country:")
+for group in country_stats.group_by[:10]:  # Top 10 countries
+    # Each group has a 'key' (the country code) and 'count'
+    print(f"  {group.key}: {group.count:,} publishers")
+```
+
+\ud83d\udca1 **Key point**: `group_by()` returns COUNTS, not the actual publishers. This is efficient for analytics.
+
+## Understanding group_by results
+
+```python
+# The result structure is different from regular queries
+result = Publishers().group_by("hierarchy_level").get()
+
+print(result.results)  # Empty list - no individual publishers returned!
+print(result.group_by)  # List of groups with counts
+
+# Access the grouped data
+print("Publishers by hierarchy level:")
+for group in result.group_by:
+    print(f"  Level {group.key}: {group.count:,} publishers")
+```
+
+## Common grouping operations
+
+### Basic grouping
+
+```python
+# Group by hierarchy level
+hierarchy_dist = Publishers().group_by("hierarchy_level").get()
+# Shows how many parent vs. subsidiary publishers
+
+# Group by country
+by_country = Publishers().group_by("country_codes").get()
+# See global distribution of publishers
+
+# Group by lineage (to analyze publisher families)
+by_lineage = Publishers().group_by("lineage").get()
+# Note: This will have many groups (one per family tree path)
+```
+
+### Summary statistics grouping
+
+```python
+# Distribution of h-index values
+h_index_dist = Publishers().group_by("summary_stats.h_index").get()
+# See how research impact is distributed
+
+# Distribution of i10-index
+i10_dist = Publishers().group_by("summary_stats.i10_index").get()
+
+# 2-year mean citedness distribution
+impact_dist = Publishers().group_by("summary_stats.2yr_mean_citedness").get()
+```
+
+## Combining filters with group_by
+
+Group_by becomes more insightful when combined with filters:
+
+```python
+# Country distribution for large publishers only
+large_pub_countries = (
+    Publishers()
+    .filter_gt(works_count=100000)  # Large publishers only
+    .group_by("country_codes")
+    .get()
+)
+print("Countries with large publishers:")
+for group in large_pub_countries.group_by:
+    print(f"  {group.key}: {group.count} large publishers")
+
+# Hierarchy levels for high-impact publishers
+high_impact_hierarchy = (
+    Publishers()
+    .filter_gt(summary_stats={"h_index": 200})
+    .group_by("hierarchy_level")
+    .get()
+)
+
+# Parent publishers by continent
+parent_by_continent = (
+    Publishers()
+    .filter(hierarchy_level=0)  # Parents only
+    .group_by("continent")
+    .get()
+)
+```
+
+## Multi-dimensional grouping
+
+While the API supports grouping by two dimensions, it's less common for publishers:
+
+```python
+# Publishers by country and hierarchy level
+country_hierarchy = Publishers().group_by(
+    "country_codes",
+    "hierarchy_level"
+).get()
+
+# This shows which countries have more complex publisher structures
+for group in country_hierarchy.group_by[:20]:
+    country, level = group.key.split('|')  # Keys are pipe-separated
+    print(f"{country} Level {level}: {group.count} publishers")
+```
+
+## Practical examples
+
+### Example 1: Analyze publisher market concentration
+
+```python
+# Get top countries by publisher count
+def analyze_market_concentration():
+    # Total publishers by country
+    by_country = Publishers().group_by("country_codes").get()
+    
+    # Large publishers by country  
+    large_by_country = (
+        Publishers()
+        .filter_gt(works_count=100000)
+        .group_by("country_codes")
+        .get()
+    )
+    
+    # Calculate concentration
+    country_data = {}
+    for group in by_country.group_by[:10]:
+        country = group.key
+        total = group.count
+        
+        # Find large publisher count for this country
+        large_count = next(
+            (g.count for g in large_by_country.group_by if g.key == country), 
+            0
+        )
+        
+        concentration = (large_count / total * 100) if total > 0 else 0
+        country_data[country] = {
+            'total': total,
+            'large': large_count,
+            'concentration': concentration
+        }
+    
+    print("Market concentration by country:")
+    for country, data in sorted(
+        country_data.items(), 
+        key=lambda x: x[1]['concentration'], 
+        reverse=True
+    ):
+        print(f"  {country}: {data['large']} of {data['total']} "
+              f"({data['concentration']:.1f}% concentration)")
+
+analyze_market_concentration()
+```
+
+### Example 2: Publisher hierarchy analysis
+
+```python
+# Analyze publisher organizational structures
+def analyze_hierarchies():
+    # Overall hierarchy distribution
+    hierarchy_dist = Publishers().group_by("hierarchy_level").get()
+    
+    print("Publisher hierarchy distribution:")
+    total_publishers = sum(g.count for g in hierarchy_dist.group_by)
+    for group in hierarchy_dist.group_by:
+        pct = (group.count / total_publishers) * 100
+        print(f"  Level {group.key}: {group.count:,} ({pct:.1f}%)")
+    
+    # Countries with complex hierarchies
+    deep_hierarchies = (
+        Publishers()
+        .filter_gt(hierarchy_level=1)  # 2+ levels deep
+        .group_by("country_codes")
+        .get()
+    )
+    
+    print("\nCountries with complex publisher hierarchies:")
+    for group in deep_hierarchies.group_by[:10]:
+        print(f"  {group.key}: {group.count} multi-level subsidiaries")
+
+analyze_hierarchies()
+```
+
+### Example 3: Impact analysis
+
+```python
+# Analyze research impact distribution
+def analyze_impact():
+    # Group by h-index ranges
+    h_ranges = [0, 50, 100, 200, 300, 500, 1000]
+    
+    print("Publishers by h-index range:")
+    for i in range(len(h_ranges) - 1):
+        range_pubs = (
+            Publishers()
+            .filter_gt(summary_stats={"h_index": h_ranges[i]})
+            .filter_lt(summary_stats={"h_index": h_ranges[i+1]})
+            .get()
+        )
+        print(f"  {h_ranges[i]}-{h_ranges[i+1]}: "
+              f"{range_pubs.meta.count} publishers")
+    
+    # Top countries by high-impact publishers
+    high_impact_countries = (
+        Publishers()
+        .filter_gt(summary_stats={"h_index": 200})
+        .group_by("country_codes")
+        .get()
+    )
+    
+    print("\nCountries with high-impact publishers (h-index > 200):")
+    for group in high_impact_countries.group_by[:10]:
+        print(f"  {group.key}: {group.count} publishers")
+
+analyze_impact()
+```
+
+## Sorting grouped results
+
+Control how results are ordered:
+
+```python
+# Default: sorted by count (descending)
+default_sort = Publishers().group_by("country_codes").get()
+# US first (most publishers), then GB, DE, etc.
+
+# Sort by key instead of count  
+alphabetical = Publishers().group_by("country_codes").sort(key="asc").get()
+# AF, AL, AM... (alphabetical by country code)
+
+# Sort by count ascending (smallest groups first)
+smallest_first = Publishers().group_by("hierarchy_level").sort(count="asc").get()
+# Rarest hierarchy levels first
+```
+
+## Important notes
+
+1. **No individual publishers returned**: `group_by()` only returns counts
+2. **Efficient for analytics**: Much faster than fetching all publishers
+3. **Limited dimensions**: Maximum 2 fields for grouping
+4. **Can handle all publishers**: With only ~10,000 total, aggregations are fast
+5. **Great for market analysis**: Understand publisher landscape without details
+
+When you need statistics about publishers, always prefer `group_by()` over fetching and counting individual records!

--- a/docs/publishers/publisher-object.md
+++ b/docs/publishers/publisher-object.md
@@ -1,0 +1,299 @@
+# Publisher object
+
+When you fetch a publisher using the Python client, you get a `Publisher` object with all of OpenAlex's data about that publisher. Here's how to access the various properties:
+
+```python
+from openalex import Publishers
+
+# Get a specific publisher
+publisher = Publishers()["P4310320990"]
+
+# The publisher object has all the data as Python attributes
+print(type(publisher))  # <class 'openalex.models.publisher.Publisher'>
+```
+
+## Basic properties
+
+```python
+# Identifiers
+print(publisher.id)  # "https://openalex.org/P4310320990"
+print(publisher.display_name)  # "Elsevier BV"
+
+# Alternate names (list of variations)
+print(publisher.alternate_titles)
+# ["Elsevier", "elsevier.com", "Elsevier Science", "\u7231\u601d\u97e6\u5c14", ...]
+
+# Hierarchy information
+print(publisher.hierarchy_level)  # 1 (has one parent above)
+print(publisher.parent_publisher)  # "https://openalex.org/P4310311775"
+
+# Country information
+print(publisher.country_codes)  # ["NL"]
+
+# Scale metrics
+print(publisher.works_count)  # 13,789,818
+print(publisher.cited_by_count)  # 407,508,754
+
+# Dates
+print(publisher.created_date)  # "2017-08-08"
+print(publisher.updated_date)  # "2024-12-25T14:04:30.578837"
+```
+
+## Hierarchy and lineage
+
+Publishers can have parent-child relationships:
+
+```python
+# Hierarchy level (0 = top parent, 1 = child, 2 = grandchild, etc.)
+print(f"Hierarchy level: {publisher.hierarchy_level}")
+
+# Direct parent
+if publisher.parent_publisher:
+    print(f"Parent: {publisher.parent_publisher}")
+    # To get parent details:
+    parent = Publishers()[publisher.parent_publisher]
+    print(f"Parent name: {parent.display_name}")
+
+# Full lineage (includes self and all parents up to root)
+print(f"Lineage ({len(publisher.lineage)} levels):")
+for i, ancestor_id in enumerate(publisher.lineage):
+    print(f"  Level {i}: {ancestor_id}")
+
+# Example lineage interpretation:
+# lineage[0] = self (P4310320990)
+# lineage[1] = parent (P4310311775)  
+# lineage[2] = grandparent (if exists)
+```
+
+## Summary statistics
+
+Citation and productivity metrics:
+
+```python
+stats = publisher.summary_stats
+if stats:
+    print(f"H-index: {stats.h_index}")  # e.g., 985
+    print(f"i10-index: {stats.i10_index:,}")  # e.g., 176,682
+    print(f"2-year mean citedness: {stats['2yr_mean_citedness']:.2f}")
+    
+    # These metrics help assess publisher impact
+    if stats.h_index > 500:
+        print("This is a very high-impact publisher")
+```
+
+## Counts by year
+
+Track publication trends over the last 10 years:
+
+```python
+print("Publication trends:")
+for count in publisher.counts_by_year:
+    print(f"  {count.year}: {count.works_count:,} works, "
+          f"{count.cited_by_count:,} citations")
+
+# Analyze trends
+if len(publisher.counts_by_year) >= 2:
+    recent = publisher.counts_by_year[0]
+    previous = publisher.counts_by_year[1]
+    growth = ((recent.works_count - previous.works_count) / 
+              previous.works_count * 100)
+    print(f"Year-over-year growth: {growth:+.1f}%")
+```
+
+## External identifiers
+
+Access all known IDs:
+
+```python
+ids = publisher.ids
+print(f"OpenAlex: {ids.openalex}")
+if ids.ror:
+    print(f"ROR: {ids.ror}")
+if ids.wikidata:
+    print(f"Wikidata: {ids.wikidata}")
+
+# Check what IDs are available
+available_ids = [
+    id_type for id_type, value in ids.dict().items() 
+    if value is not None
+]
+print(f"Available IDs: {', '.join(available_ids)}")
+```
+
+## Images
+
+Publisher logos and seals:
+
+```python
+# Full-size image (usually from Wikimedia)
+if publisher.image_url:
+    print(f"Logo URL: {publisher.image_url}")
+
+# Thumbnail version
+if publisher.image_thumbnail_url:
+    print(f"Thumbnail: {publisher.image_thumbnail_url}")
+    # You can modify the width parameter in the URL:
+    # Change "width=300" to "width=500" for larger thumbnail
+```
+
+## Roles
+
+Publishers can have multiple roles in the academic ecosystem:
+
+```python
+# A publisher might also be a funder or institution
+print(f"This organization has {len(publisher.roles)} roles:")
+
+for role in publisher.roles:
+    print(f"\n{role.role.capitalize()}:")
+    print(f"  ID: {role.id}")
+    print(f"  Works count: {role.works_count:,}")
+
+# Example: Yale University might have:
+# - role: "institution" (as a university)
+# - role: "publisher" (Yale University Press)
+# - role: "funder" (funding research)
+```
+
+## Sources API URL
+
+Get all journals/sources from this publisher:
+
+```python
+# This is the API URL to get all sources
+print(f"Sources URL: {publisher.sources_api_url}")
+
+# To actually fetch the sources using the client:
+from openalex import Sources
+
+# Get all sources published by this publisher
+publisher_sources = Sources().filter(
+    host_organization={"id": publisher.id}
+).get()
+
+print(f"{publisher.display_name} publishes {publisher_sources.meta.count} sources")
+
+# Show some example journals
+for source in publisher_sources.results[:5]:
+    print(f"  - {source.display_name}")
+    if source.issn_l:
+        print(f"    ISSN-L: {source.issn_l}")
+```
+
+## Working with publisher hierarchies
+
+### Get all subsidiaries
+
+```python
+# Find all children of this publisher
+children = Publishers().filter(parent_publisher=publisher.id).get()
+
+print(f"{publisher.display_name} has {children.meta.count} direct subsidiaries:")
+for child in children.results:
+    print(f"  - {child.display_name}")
+
+# Get entire family tree (all descendants)
+family = Publishers().filter(lineage=publisher.id).get()
+print(f"Entire family: {family.meta.count} publishers")
+```
+
+### Navigate up the hierarchy
+
+```python
+def get_publisher_chain(publisher_id):
+    """Get the full chain from publisher to top parent."""
+    chain = []
+    current_id = publisher_id
+    
+    while current_id:
+        pub = Publishers()[current_id]
+        chain.append(pub)
+        current_id = pub.parent_publisher
+    
+    return chain
+
+# Example usage
+chain = get_publisher_chain(publisher.id)
+print("Publisher hierarchy (child to parent):")
+for i, pub in enumerate(chain):
+    indent = "  " * i
+    print(f"{indent}\u2192 {pub.display_name} (Level {pub.hierarchy_level})")
+```
+
+## Analyze publisher portfolio
+
+```python
+# Get a sample of recent works from this publisher
+from openalex import Works
+
+recent_works = (
+    Works()
+    .filter(primary_location={"source": {"host_organization": publisher.id}})
+    .filter(publication_year=2023)
+    .get(per_page=100)
+)
+
+# Analyze work types
+work_types = {}
+for work in recent_works.results:
+    work_type = work.type or "unknown"
+    work_types[work_type] = work_types.get(work_type, 0) + 1
+
+print(f"\nWork types published in 2023:")
+for work_type, count in sorted(work_types.items(), key=lambda x: x[1], reverse=True):
+    print(f"  {work_type}: {count}")
+
+# Analyze open access
+oa_count = sum(1 for w in recent_works.results if w.open_access.is_oa)
+oa_percentage = (oa_count / len(recent_works.results)) * 100
+print(f"\nOpen Access rate: {oa_percentage:.1f}%")
+```
+
+## Geographic analysis
+
+```python
+# For publishers with multiple country codes
+if len(publisher.country_codes) > 1:
+    print(f"International publisher with presence in:")
+    for country in publisher.country_codes:
+        print(f"  - {country}")
+
+# Find other publishers in the same country
+same_country = Publishers().filter(
+    country_codes=publisher.country_codes[0]
+).get()
+print(f"\nOther publishers in {publisher.country_codes[0]}: "
+      f"{same_country.meta.count - 1}")
+```
+
+## Handling missing data
+
+Many fields can be None or empty:
+
+```python
+# Safe access patterns
+if publisher.parent_publisher:
+    print(f"Has parent: {publisher.parent_publisher}")
+else:
+    print("This is a top-level publisher")
+
+if publisher.image_url:
+    print(f"Logo available: {publisher.image_url}")
+else:
+    print("No logo available")
+
+# Handle missing statistics
+if publisher.summary_stats and publisher.summary_stats.h_index is not None:
+    print(f"H-index: {publisher.summary_stats.h_index}")
+else:
+    print("H-index not calculated")
+
+# Safe navigation for nested fields
+parent_name = None
+if publisher.parent_publisher:
+    try:
+        parent = Publishers()[publisher.parent_publisher]
+        parent_name = parent.display_name
+    except Exception:
+        parent_name = "Unknown"
+```

--- a/docs/publishers/search-publishers.md
+++ b/docs/publishers/search-publishers.md
@@ -1,0 +1,269 @@
+# Search publishers
+
+The best way to search for publishers is to use the `search` method, which searches the `display_name` and `alternate_titles` fields:
+
+```python
+from openalex import Publishers
+
+# Search for publishers by name
+springer_search = Publishers().search("springer")
+
+# Execute to get the first page of results
+results = springer_search.get()
+
+print(f"Found {results.meta.count} publishers matching 'springer'")
+for publisher in results.results[:5]:
+    print(f"- {publisher.display_name}")
+    if publisher.alternate_titles:
+        print(f"  Also known as: {', '.join(publisher.alternate_titles[:3])}")
+```
+
+## How publisher search works
+
+The search checks both primary and alternate names:
+
+```python
+# This searches both display_name and alternate_titles
+elsevier_results = Publishers().search("elsevier").get()
+
+# Example matches might include:
+# - "Elsevier BV" (display_name)
+# - "Elsevier Science" (alternate_title)
+# - "Elsevier Health Sciences" (display_name)
+# - Publishers with "\u0627\u0644\u0633\u0641\u06cc\u0631" (Arabic for Elsevier) in alternate_titles
+```
+
+\ud83d\udca1 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+
+## Search a specific field
+
+You can also use search as a filter:
+
+```python
+# Search only in display_name (not alternate_titles)
+display_only = Publishers().filter(
+    display_name={"search": "elsevier"}
+).get()
+
+# Or use the search_filter method
+search_filter = Publishers().search_filter(
+    display_name="oxford"
+).get()
+
+# Default search (same as .search() method)
+default_search = Publishers().filter(
+    default={"search": "academic press"}
+).get()
+```
+
+Available search fields:
+
+| Search filter | Field that is searched | Python method |
+|---------------|------------------------|---------------|
+| `display_name.search` | `display_name` only | `.search_filter(display_name="...")` |
+| `default.search` | `display_name` and `alternate_titles` | `.filter(default={"search": "..."})` |
+
+## Autocomplete publishers
+
+Create a fast type-ahead search experience:
+
+```python
+# Get autocomplete suggestions
+suggestions = Publishers().autocomplete("els")
+
+# Returns fast, lightweight results
+for publisher in suggestions.results:
+    print(f"{publisher.display_name}")
+    print(f"  Works: {publisher.works_count:,}")
+    print(f"  Citations: {publisher.cited_by_count:,}")
+    if publisher.external_id:  # Wikidata ID
+        print(f"  Wikidata: {publisher.external_id}")
+```
+
+Example output:
+```
+Elsevier BV
+  Works: 20,311,868
+  Citations: 407,508,754
+  Wikidata: https://www.wikidata.org/entity/Q746413
+
+Else Kr\u00f6ner-Fresenius Foundation
+  Works: 1,234
+  Citations: 45,678
+  Wikidata: https://www.wikidata.org/entity/Q1333765
+```
+
+## Combining search with filters
+
+Search is most powerful when combined with filters:
+
+```python
+# Search for US university presses
+us_uni_presses = (
+    Publishers()
+    .search("University Press")
+    .filter(country_codes="US")
+    .get()
+)
+
+# Large publishers with "Science" in name
+science_publishers = (
+    Publishers()
+    .search("Science")
+    .filter_gt(works_count=10000)
+    .sort(works_count="desc")
+    .get()
+)
+
+# Top-level publishers only (no subsidiaries)
+parent_publishers = (
+    Publishers()
+    .search("Nature")
+    .filter(hierarchy_level=0)
+    .get()
+)
+
+# High-impact medical publishers
+medical_publishers = (
+    Publishers()
+    .search("Medical")
+    .filter_gt(summary_stats={"h_index": 100})
+    .get()
+)
+```
+
+## Search strategies
+
+### Finding publisher families
+
+```python
+# When searching for a publisher group, check hierarchy
+def find_publisher_family(search_term):
+    # First, find potential matches
+    matches = Publishers().search(search_term).get(per_page=20)
+    
+    families = {}
+    for pub in matches.results:
+        # Get the top-level parent
+        if pub.hierarchy_level == 0:
+            family_key = pub.id
+        else:
+            # Find parent through lineage
+            family_key = pub.lineage[-1] if pub.lineage else pub.id
+        
+        if family_key not in families:
+            families[family_key] = []
+        families[family_key].append(pub)
+    
+    return families
+
+# Example usage
+nature_families = find_publisher_family("Nature")
+for parent_id, members in nature_families.items():
+    print(f"\nFamily {parent_id}:")
+    for pub in members:
+        indent = "  " * pub.hierarchy_level
+        print(f"{indent}{pub.display_name}")
+```
+
+### Finding regional publishers
+
+```python
+# Search for publishers in specific regions
+def find_regional_publishers(search_term, country_codes):
+    return (
+        Publishers()
+        .search(search_term)
+        .filter(country_codes=country_codes)
+        .sort(works_count="desc")
+        .get()
+    )
+
+# Find Asian academic publishers
+asian_academic = find_regional_publishers(
+    "Academic", 
+    ["CN", "JP", "KR", "IN", "SG"]
+)
+
+# Find European open access publishers
+eu_oa_publishers = find_regional_publishers(
+    "Open Access",
+    ["DE", "NL", "GB", "FR", "CH"]
+)
+```
+
+## Common search patterns
+
+### Disambiguating similar names
+
+```python
+# Many publishers have similar names
+cambridge_search = Publishers().search("Cambridge").get()
+
+# Distinguish between them using additional filters
+cambridge_uni_press = (
+    Publishers()
+    .search("Cambridge University Press")
+    .filter(country_codes="GB")
+    .get()
+)
+
+# Or use works_count to find the major one
+major_cambridge = (
+    Publishers()
+    .search("Cambridge")
+    .sort(works_count="desc")
+    .get(per_page=1)
+).results[0]
+```
+
+### Finding imprints and subsidiaries
+
+```python
+# Find all Springer-related entities
+springer_all = Publishers().search("Springer").get(per_page=50)
+
+# Separate parents from children
+parents = [p for p in springer_all.results if p.hierarchy_level == 0]
+imprints = [p for p in springer_all.results if p.hierarchy_level > 0]
+
+print(f"Found {len(parents)} parent companies")
+print(f"Found {len(imprints)} imprints/subsidiaries")
+
+# Group by parent
+by_parent = {}
+for pub in springer_all.results:
+    parent = pub.lineage[-1] if pub.lineage else pub.id
+    if parent not in by_parent:
+        by_parent[parent] = []
+    by_parent[parent].append(pub)
+```
+
+## Search tips
+
+1. **Check alternate titles**: Publishers often have many name variants
+2. **Use hierarchy**: Parent/child relationships help disambiguate
+3. **Consider country**: Many publishers have regional branches
+4. **Look at scale**: Works_count helps identify major vs. minor publishers
+5. **Try partial names**: "Elsevier" finds "Elsevier BV", "Elsevier Ltd", etc.
+
+```python
+# Example: Find the "real" publisher among many matches
+def find_main_publisher(search_term):
+    results = Publishers().search(search_term).get(per_page=10)
+    
+    # Strategy 1: Highest works count
+    by_works = max(results.results, key=lambda p: p.works_count)
+    
+    # Strategy 2: Top-level only
+    parents = [p for p in results.results if p.hierarchy_level == 0]
+    
+    # Strategy 3: Most cited
+    by_citations = max(results.results, key=lambda p: p.cited_by_count)
+    
+    print(f"Most works: {by_works.display_name} ({by_works.works_count:,})")
+    print(f"Parent companies: {[p.display_name for p in parents]}")
+    print(f"Most cited: {by_citations.display_name} ({by_citations.cited_by_count:,})")
+    
+    return by_works  # Usually the best choice
+```


### PR DESCRIPTION
## Summary
- document publishers under docs/publishers using Python client examples

## Testing
- `pytest -q` *(fails: unrecognized arguments)*
- `pip install -r requirements-dev.txt` *(fails: dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68485196d544832badd36c43cf0a0c63