### PR TITLE
Refactor utilities and expose exports

### DIFF
--- a/openalex/api.py
+++ b/openalex/api.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from structlog import get_logger
 
+__all__ = ["APIConnection", "AsyncAPIConnection", "get_connection"]
+
 from .config import OpenAlexConfig
 from .constants import DEFAULT_RATE_LIMIT
 from .exceptions import NetworkError, TimeoutError

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -9,6 +9,19 @@ if TYPE_CHECKING:  # pragma: no cover
 
 from pydantic import ValidationError
 
+__all__ = [
+    "Authors",
+    "BaseEntity",
+    "Concepts",
+    "Funders",
+    "Institutions",
+    "Keywords",
+    "Publishers",
+    "Sources",
+    "Topics",
+    "Works",
+]
+
 from .api import get_connection
 from .constants import (
     AUTOCOMPLETE_PATH,
@@ -65,6 +78,11 @@ class BaseEntity(Generic[T, F]):
 
         self._config = config
         self._connection = get_connection(config)
+
+    @property
+    def config(self) -> OpenAlexConfig:
+        """Return configuration for this entity."""
+        return self._config
 
     def __repr__(self) -> str:
         config_parts = []

--- a/openalex/models/base.py
+++ b/openalex/models/base.py
@@ -10,6 +10,22 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer
 
 from ..constants import FILTER_DEFAULT_PER_PAGE, FIRST_PAGE
 
+__all__ = [
+    "AutocompleteResult",
+    "CountsByYear",
+    "DehydratedEntity",
+    "EntityType",
+    "Geo",
+    "GroupByResult",
+    "InternationalNames",
+    "ListResult",
+    "Meta",
+    "OpenAlexBase",
+    "OpenAlexEntity",
+    "Role",
+    "SummaryStats",
+]
+
 
 class EntityType(str, Enum):
     """OpenAlex entity types."""

--- a/openalex/models/filters.py
+++ b/openalex/models/filters.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, Field, field_validator
 
 from ..constants import FILTER_DEFAULT_PER_PAGE, FIRST_PAGE
 
+__all__ = [
+    "BaseFilter",
+    "GroupBy",
+    "SortOrder",
+]
+
 
 class SortOrder(str, Enum):
     """Sort order options."""

--- a/openalex/models/work.py
+++ b/openalex/models/work.py
@@ -10,6 +10,13 @@ from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
 from ..utils.text import invert_abstract
 
+__all__ = [
+    "Work",
+    "WorkIds",
+    "WorkType",
+    "WorksFilter",
+]
+
 if TYPE_CHECKING:
     from .institution import InstitutionType
     from .topic import TopicHierarchy

--- a/openalex/query.py
+++ b/openalex/query.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:  # pragma: no cover - for type checking only
 from .models import BaseFilter, ListResult
 from .utils.pagination import MAX_PER_PAGE, Paginator
 
+__all__ = [
+    "Query",
+    "gt_",
+    "lt_",
+    "not_",
+    "or_",
+]
+
 T = TypeVar("T")
 F = TypeVar("F", bound=BaseFilter)
 

--- a/openalex/utils/common.py
+++ b/openalex/utils/common.py
@@ -22,11 +22,16 @@ KEY_MAP: Final[dict[str, str]] = {
 }
 
 
+def _normalize_keys(params: dict[str, Any]) -> dict[str, Any]:
+    """Return a new mapping with API parameter names normalized."""
+    return {KEY_MAP.get(k, k): v for k, v in params.items()}
+
+
 def normalize_params(params: dict[str, Any]) -> dict[str, Any]:
     """Normalize parameter keys and values for API requests."""
+    cleaned = _normalize_keys(params)
     normalized: dict[str, Any] = {}
-    for key, value in params.items():
-        key = KEY_MAP.get(key, key)
+    for key, value in cleaned.items():
         if key == "select" and isinstance(value, list):
             normalized[key] = ",".join(value)
         else:
@@ -36,16 +41,13 @@ def normalize_params(params: dict[str, Any]) -> dict[str, Any]:
 
 def strip_id_prefix(value: str, prefix: str = OPENALEX_ID_PREFIX) -> str:
     """Remove URL-style prefix from an OpenAlex identifier."""
-    if value.startswith(prefix):
-        return value[len(prefix) :]
-    return value.rsplit("/", 1)[-1]
+    trimmed = value.removeprefix(prefix)
+    return trimmed.rsplit("/", 1)[-1]
 
 
 def ensure_prefix(value: str, prefix: str) -> str:
     """Return ``value`` with ``prefix`` if missing."""
-    if value.startswith(prefix):
-        return value
-    return f"{prefix}{value}"
+    return value if value.startswith(prefix) else f"{prefix}{value}"
 
 
 def empty_list_result() -> ListResult[Any]:

--- a/openalex/utils/text.py
+++ b/openalex/utils/text.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["invert_abstract"]
+
 
 def invert_abstract(inverted_index: dict[str, list[int]] | None) -> str | None:
     """Convert inverted abstract index to plaintext.
@@ -15,12 +17,10 @@ def invert_abstract(inverted_index: dict[str, list[int]] | None) -> str | None:
     if not inverted_index:
         return None
 
-    word_positions: list[tuple[str, int]] = []
-    for word, positions in inverted_index.items():
-        for pos in positions:
-            word_positions.append((word, pos))
-
-    word_positions.sort(key=lambda x: x[1])
-    words = [word for word, _ in word_positions]
-
-    return " ".join(words)
+    word_positions = [
+        (word, pos)
+        for word, positions in inverted_index.items()
+        for pos in positions
+    ]
+    word_positions.sort(key=lambda item: item[1])
+    return " ".join(word for word, _ in word_positions)


### PR DESCRIPTION
## Summary
- provide `__all__` exports for many modules
- refactor common parameter utils
- simplify parameter serialization code
- add helper property on `BaseEntity`
- tidy up text utils

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486e5f353c832bb0cde725a66a54a6