### PR TITLE
Refactor utils and add small features

### DIFF
--- a/openalex/api.py
+++ b/openalex/api.py
@@ -113,6 +113,11 @@ class AsyncAPIConnection:
         if self._client:
             await self._client.aclose()
 
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client:
+            await self._client.aclose()
+
     async def request(
         self,
         method: str,

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -58,6 +58,8 @@ F = TypeVar("F", bound="BaseFilter")
 class BaseEntity(Generic[T, F]):
     """Base class for entity direct access."""
 
+    __slots__ = ("_config", "_connection")
+
     endpoint: str = ""
     model_class: type[T] = None  # type: ignore
 

--- a/openalex/models/base.py
+++ b/openalex/models/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import date, datetime
 from enum import Enum
 from typing import Any, Generic, TypeVar
@@ -148,6 +149,25 @@ class ListResult(OpenAlexBase, Generic[T]):
     meta: Meta
     results: list[T] = Field(default_factory=list)
     group_by: list[GroupByResult] | None = None
+
+    def __len__(self) -> int:
+        """Return the number of results."""
+        return len(self.results)
+
+    def iter_results(self) -> Iterator[T]:
+        """Iterate over contained results."""
+        return iter(self.results)
+
+    def __getitem__(self, index: int) -> T:
+        """Get result at ``index``."""
+        return self.results[index]
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        """Truthiness based on contained results."""
+        return bool(self.results)
+
+    def __repr__(self) -> str:  # pragma: no cover - for debugging only
+        return f"<ListResult {len(self)} results>"
 
 
 class AutocompleteResult(OpenAlexBase):

--- a/openalex/query.py
+++ b/openalex/query.py
@@ -23,7 +23,7 @@ F = TypeVar("F", bound=BaseFilter)
 
 
 class or_(dict[str, Any]):  # noqa: N801
-    """Logical OR expression for filters."""
+    """Container to mark a filter dictionary for OR combination."""
 
 
 class _LogicalExpression:
@@ -59,6 +59,8 @@ class lt_(_LogicalExpression):  # noqa: N801
 class Query(Generic[T, F]):
     """Fluent interface for building API queries."""
 
+    __slots__ = ("entity", "params")
+
     def __init__(
         self,
         entity: BaseEntity[T, F],
@@ -77,6 +79,8 @@ class Query(Generic[T, F]):
 
     # internal helper
     def _clone(self, **updates: Any) -> Query[T, F]:
+        """Return a new :class:`Query` with updated parameters."""
+
         new_params = {**self.params}
         for key, value in updates.items():
             if key == "filter" and value is not None:

--- a/openalex/utils/__init__.py
+++ b/openalex/utils/__init__.py
@@ -7,7 +7,12 @@ from ..constants import (
     ORCID_URL_PREFIX,
     PMID_PREFIX,
 )
-from .common import empty_list_result, ensure_prefix, strip_id_prefix
+from .common import (
+    empty_list_result,
+    ensure_prefix,
+    is_openalex_id,
+    strip_id_prefix,
+)
 from .pagination import AsyncPaginator, Paginator
 from .params import normalize_params
 from .rate_limit import (
@@ -44,6 +49,7 @@ __all__ = [
     "empty_list_result",
     "ensure_prefix",
     "invert_abstract",
+    "is_openalex_id",
     "is_retryable_error",
     "normalize_params",
     "rate_limited",

--- a/openalex/utils/common.py
+++ b/openalex/utils/common.py
@@ -11,6 +11,7 @@ __all__ = [
     "OPENALEX_ID_PREFIX",
     "empty_list_result",
     "ensure_prefix",
+    "is_openalex_id",
     "strip_id_prefix",
 ]
 
@@ -19,6 +20,11 @@ def strip_id_prefix(value: str, prefix: str = OPENALEX_ID_PREFIX) -> str:
     """Remove URL-style prefix from an OpenAlex identifier."""
     trimmed = value.removeprefix(prefix)
     return trimmed.rsplit("/", 1)[-1]
+
+
+def is_openalex_id(value: str) -> bool:
+    """Return ``True`` if the value looks like an OpenAlex ID."""
+    return value.startswith(OPENALEX_ID_PREFIX)
 
 
 def ensure_prefix(value: str, prefix: str) -> str:

--- a/openalex/utils/pagination.py
+++ b/openalex/utils/pagination.py
@@ -68,6 +68,11 @@ class Paginator(Generic[T]):
         self.max_results = max_results
         self._total_fetched = 0
 
+    @property
+    def total_fetched(self) -> int:
+        """Number of results yielded so far."""
+        return self._total_fetched
+
     def __iter__(self) -> Iterator[T]:
         """Iterate over all results."""
         page: int | None = FIRST_PAGE
@@ -209,6 +214,11 @@ class AsyncPaginator(Generic[T]):
         self.max_results = max_results
         self.concurrency = concurrency
         self._total_fetched = 0
+
+    @property
+    def total_fetched(self) -> int:
+        """Number of results yielded so far."""
+        return self._total_fetched
 
     async def __aiter__(self) -> AsyncIterator[T]:
         """Iterate over all results asynchronously."""

--- a/openalex/utils/rate_limit.py
+++ b/openalex/utils/rate_limit.py
@@ -13,6 +13,7 @@ from structlog import get_logger
 DEFAULT_BUFFER: Final = 0.1
 
 __all__ = [
+    "DEFAULT_BUFFER",
     "AsyncRateLimiter",
     "RateLimiter",
     "SlidingWindowRateLimiter",
@@ -30,6 +31,14 @@ T = TypeVar("T")
 
 class RateLimiter:
     """Token bucket rate limiter."""
+
+    __slots__ = (
+        "burst",
+        "last_update",
+        "lock",
+        "rate",
+        "tokens",
+    )
 
     def __init__(
         self,
@@ -102,9 +111,30 @@ class RateLimiter:
 
             return False
 
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<RateLimiter rate={self.rate} burst={self.burst}>"
+
+    def __enter__(self) -> RateLimiter:
+        """Context manager entry."""
+        wait_time = self.acquire()
+        if wait_time > 0:
+            time.sleep(wait_time)
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        return
+
 
 class SlidingWindowRateLimiter:
     """Sliding window rate limiter."""
+
+    __slots__ = (
+        "lock",
+        "max_requests",
+        "requests",
+        "window_seconds",
+    )
 
     def __init__(
         self,
@@ -167,9 +197,34 @@ class SlidingWindowRateLimiter:
 
             return False
 
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<SlidingWindowRateLimiter max={self.max_requests} window={self.window_seconds}>"
+
+    def __enter__(self) -> SlidingWindowRateLimiter:
+        """Context manager entry."""
+        wait_time = self.acquire()
+        if wait_time > 0:
+            time.sleep(wait_time)
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        return
+
 
 class AsyncRateLimiter:
     """Async token bucket rate limiter."""
+
+    __slots__ = (
+        "burst",
+        "last_update",
+        "lock",
+        "rate",
+        "tokens",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<AsyncRateLimiter rate={self.rate} burst={self.burst}>"
 
     def __init__(
         self,

--- a/openalex/utils/retry.py
+++ b/openalex/utils/retry.py
@@ -171,6 +171,8 @@ def async_with_retry(
 class RetryHandler:
     """Handler for retry logic with rate limit awareness."""
 
+    __slots__ = ("_rate_limit_reset", "config")
+
     def __init__(self, config: RetryConfig | None = None) -> None:
         """Initialize retry handler."""
         self.config = config or RetryConfig()

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -1,6 +1,7 @@
 from openalex.utils import (
     empty_list_result,
     ensure_prefix,
+    is_openalex_id,
     normalize_params,
     strip_id_prefix,
 )
@@ -14,6 +15,11 @@ def test_ensure_prefix() -> None:
 def test_strip_id_prefix() -> None:
     assert strip_id_prefix("https://openalex.org/W123") == "W123"
     assert strip_id_prefix("W123") == "W123"
+
+
+def test_is_openalex_id() -> None:
+    assert is_openalex_id("https://openalex.org/W1")
+    assert not is_openalex_id("W1")
 
 
 def test_normalize_params_select_list() -> None:


### PR DESCRIPTION
## Summary
- add iterator helpers on `ListResult`
- expand rate limiter functionality
- expose `is_openalex_id` helper and tests
- small refactors across API and query

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487c91dec4832b875fd73dd1f6d10d