### PR TITLE
Fix lint issues and streamline imports

### DIFF
--- a/openalex/api.py
+++ b/openalex/api.py
@@ -59,9 +59,9 @@ class APIConnection:
         params = params or {}
         params["mailto"] = self.config.email
         if self.config.api_key:
-            kwargs.setdefault("headers", {})["Authorization"] = (
-                f"Bearer {self.config.api_key}"
-            )
+            kwargs.setdefault("headers", {})[
+                "Authorization"
+            ] = f"Bearer {self.config.api_key}"
 
         wait = self.rate_limiter.acquire()
         if wait > 0:
@@ -133,9 +133,9 @@ class AsyncAPIConnection:
         params = params or {}
         params["mailto"] = self.config.email
         if self.config.api_key:
-            kwargs.setdefault("headers", {})["Authorization"] = (
-                f"Bearer {self.config.api_key}"
-            )
+            kwargs.setdefault("headers", {})[
+                "Authorization"
+            ] = f"Bearer {self.config.api_key}"
 
         wait = await self.rate_limiter.acquire()
         if wait > 0:

--- a/openalex/models/author.py
+++ b/openalex/models/author.py
@@ -147,6 +147,9 @@ class Author(OpenAlexEntity):
         return [c.display_name for c in self.x_concepts if c.display_name]
 
 
-from .work import DehydratedConcept, DehydratedInstitution  # noqa: E402,TC001
+from .work import (  # noqa: E402,TCH001
+    DehydratedConcept,
+    DehydratedInstitution,
+)
 
 Author.model_rebuild()

--- a/openalex/models/base.py
+++ b/openalex/models/base.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 from enum import Enum
 from typing import Any, Generic, TypeVar
 

--- a/openalex/models/institution.py
+++ b/openalex/models/institution.py
@@ -278,7 +278,7 @@ class Institution(OpenAlexEntity):
         )
 
 
-from .topic import TopicHierarchy  # noqa: E402,TC001
-from .work import DehydratedConcept  # noqa: E402,TC001
+from .topic import TopicHierarchy  # noqa: E402,TCH001
+from .work import DehydratedConcept  # noqa: E402,TCH001
 
 Institution.model_rebuild()

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -209,6 +209,6 @@ class Source(OpenAlexEntity):
         )
 
 
-from .work import DehydratedConcept  # noqa: E402,TC001
+from .work import DehydratedConcept  # noqa: E402,TCH001
 
 Source.model_rebuild()

--- a/openalex/models/topic.py
+++ b/openalex/models/topic.py
@@ -163,6 +163,6 @@ class Topic(OpenAlexEntity):
         }
 
 
-from .work import DehydratedTopic  # noqa: E402,TC001
+from .work import DehydratedTopic  # noqa: E402,TCH001
 
 Topic.model_rebuild()

--- a/openalex/models/work.py
+++ b/openalex/models/work.py
@@ -502,8 +502,8 @@ class InstitutionsFilter(BaseFilter):
         return self.model_copy(update={"filter": current_filter})
 
 
-from .institution import InstitutionType  # noqa: E402,TC001
-from .topic import TopicHierarchy  # noqa: E402,TC001
+from .institution import InstitutionType  # noqa: E402,TCH001
+from .topic import TopicHierarchy  # noqa: E402,TCH001
 
 DehydratedTopic.model_rebuild()
 DehydratedInstitution.model_rebuild()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from httpx import Response
 from openalex import OpenAlexConfig
 
 
-@pytest.fixture
+@pytest.fixture()
 def config() -> OpenAlexConfig:
     """Create test configuration."""
     return OpenAlexConfig(
@@ -22,7 +22,7 @@ def config() -> OpenAlexConfig:
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_work_response() -> dict[str, Any]:
     """Mock work API response."""
     return {
@@ -75,7 +75,7 @@ def mock_work_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_author_response() -> dict[str, Any]:
     """Mock author API response."""
     return {
@@ -115,7 +115,7 @@ def mock_author_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_list_response(mock_work_response: dict[str, Any]) -> dict[str, Any]:
     """Mock list API response."""
     return {
@@ -130,7 +130,7 @@ def mock_list_response(mock_work_response: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_autocomplete_response() -> dict[str, Any]:
     """Mock autocomplete API response."""
     return {
@@ -159,7 +159,7 @@ def mock_autocomplete_response() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_error_response() -> dict[str, Any]:
     """Mock error API response."""
     return {

--- a/tests/models/test_author.py
+++ b/tests/models/test_author.py
@@ -14,7 +14,7 @@ from openalex.models import (
 class TestAuthor:
     """Test Author model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_author_data(self) -> dict[str, Any]:
         """Comprehensive author data based on real OpenAlex API response."""
         return {
@@ -126,7 +126,7 @@ class TestAuthor:
             "updated_date": "2024-12-16T09:27:51.699330",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def minimal_author_data(self) -> dict[str, Any]:
         """Minimal author data for edge case testing."""
         return {
@@ -136,7 +136,7 @@ class TestAuthor:
             "cited_by_count": 0,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def author_with_multiple_affiliations_data(self) -> dict[str, Any]:
         """Author with complex affiliation history."""
         return {

--- a/tests/models/test_concept.py
+++ b/tests/models/test_concept.py
@@ -15,7 +15,7 @@ from openalex.models import (
 class TestConcept:
     """Test Concept model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_concept_data(self) -> dict[str, Any]:
         """Comprehensive concept data based on real OpenAlex API response."""
         return {
@@ -139,7 +139,7 @@ class TestConcept:
             "updated_date": "2024-12-16T11:23:45.678901",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def hierarchical_concept_data(self) -> dict[str, Any]:
         """Concept with complex hierarchy."""
         return {
@@ -183,7 +183,7 @@ class TestConcept:
             ],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def deep_hierarchy_concept_data(self) -> dict[str, Any]:
         """Concept at level 5 with full ancestry."""
         return {

--- a/tests/models/test_funder.py
+++ b/tests/models/test_funder.py
@@ -12,7 +12,7 @@ from openalex.models import CountsByYear, Funder
 class TestFunder:
     """Test Funder model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def government_funder_data(self) -> dict[str, Any]:
         """Government funder data based on real OpenAlex API response."""
         return {
@@ -66,7 +66,7 @@ class TestFunder:
             "updated_date": "2024-12-16T13:45:67.890123",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def private_foundation_data(self) -> dict[str, Any]:
         """Private foundation funder data."""
         return {
@@ -102,7 +102,7 @@ class TestFunder:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def european_funder_data(self) -> dict[str, Any]:
         """European research council funder data."""
         return {

--- a/tests/models/test_institution.py
+++ b/tests/models/test_institution.py
@@ -15,7 +15,7 @@ from openalex.models import (
 class TestInstitution:
     """Test Institution model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_institution_data(self) -> dict[str, Any]:
         """Comprehensive institution data based on real OpenAlex API response."""
         return {
@@ -231,7 +231,7 @@ class TestInstitution:
             "updated_date": "2024-12-16T09:53:16.081181",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def company_institution_data(self) -> dict[str, Any]:
         """Company institution data."""
         return {
@@ -269,7 +269,7 @@ class TestInstitution:
             "repositories": [],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def hierarchical_institution_data(self) -> dict[str, Any]:
         """Institution with complex hierarchy."""
         return {

--- a/tests/models/test_keyword.py
+++ b/tests/models/test_keyword.py
@@ -11,7 +11,7 @@ from openalex.models import Keyword
 class TestKeyword:
     """Test Keyword model with comprehensive fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_keyword_data(self) -> dict[str, Any]:
         """Comprehensive keyword data based on real OpenAlex API response."""
         return {
@@ -22,7 +22,7 @@ class TestKeyword:
             "cited_by_count": 12345678,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def popular_keyword_data(self) -> dict[str, Any]:
         """Popular keyword with high metrics."""
         return {
@@ -33,7 +33,7 @@ class TestKeyword:
             "cited_by_count": 34567890,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def new_keyword_data(self) -> dict[str, Any]:
         """New keyword with low metrics."""
         return {

--- a/tests/models/test_publisher.py
+++ b/tests/models/test_publisher.py
@@ -12,7 +12,7 @@ from openalex.models import Publisher
 class TestPublisher:
     """Test Publisher model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def parent_publisher_data(self) -> dict[str, Any]:
         """Parent publisher data based on real OpenAlex API response."""
         return {
@@ -72,7 +72,7 @@ class TestPublisher:
             "updated_date": "2024-12-16T12:34:56.789012",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def child_publisher_data(self) -> dict[str, Any]:
         """Child publisher data (imprint)."""
         return {
@@ -117,7 +117,7 @@ class TestPublisher:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def university_press_publisher_data(self) -> dict[str, Any]:
         """University press publisher data."""
         return {

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -17,7 +17,7 @@ from openalex.models import (
 class TestSource:
     """Test Source model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def journal_source_data(self) -> dict[str, Any]:
         """Comprehensive journal source data based on real OpenAlex API response."""
         return {
@@ -100,7 +100,7 @@ class TestSource:
             "updated_date": "2024-12-16T10:12:34.567890",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def repository_source_data(self) -> dict[str, Any]:
         """Repository source data."""
         return {
@@ -146,7 +146,7 @@ class TestSource:
             },
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def conference_source_data(self) -> dict[str, Any]:
         """Conference source data."""
         return {
@@ -177,7 +177,7 @@ class TestSource:
             ],
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def ebook_platform_source_data(self) -> dict[str, Any]:
         """E-book platform source data."""
         return {

--- a/tests/models/test_topic.py
+++ b/tests/models/test_topic.py
@@ -17,7 +17,7 @@ from openalex.models import (
 class TestTopic:
     """Test Topic model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def domain_topic_data(self) -> dict[str, Any]:
         """Domain-level topic data (level 0)."""
         return {
@@ -60,7 +60,7 @@ class TestTopic:
             "updated_date": "2024-12-16T14:56:78.901234",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def field_topic_data(self) -> dict[str, Any]:
         """Field-level topic data (level 1)."""
         return {
@@ -101,7 +101,7 @@ class TestTopic:
             "cited_by_count": 67890123,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def subfield_topic_data(self) -> dict[str, Any]:
         """Subfield-level topic data (level 2) - most detailed level."""
         return {
@@ -152,7 +152,7 @@ class TestTopic:
             "updated_date": "2024-12-16T15:12:34.567890",
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def interdisciplinary_topic_data(self) -> dict[str, Any]:
         """Interdisciplinary topic spanning multiple domains."""
         return {

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -27,7 +27,7 @@ from openalex.models.work import (
 class TestWork:
     """Test Work model with comprehensive realistic fixtures."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def comprehensive_work_data(self) -> dict[str, Any]:
         """Comprehensive work data based on real OpenAlex API response."""
         return {

--- a/tests/utils/test_pagination.py
+++ b/tests/utils/test_pagination.py
@@ -47,7 +47,7 @@ def test_paginator_iteration() -> None:
     assert paginator.count() == total
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather() -> None:
     total = 5
 
@@ -93,7 +93,7 @@ def test_paginator_error() -> None:
         list(paginator)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_first_all() -> None:
     total = 5
 
@@ -114,7 +114,7 @@ async def test_async_paginator_pages_first_all() -> None:
     assert len(results) == total
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_error() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         msg = "bad"
@@ -130,7 +130,7 @@ async def test_async_paginator_error() -> None:
         await iterate_paginator()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather_max_results() -> None:
     total = 10
 
@@ -162,7 +162,7 @@ def test_paginator_pages_error() -> None:
         next(paginator.pages())
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_error() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         msg = "boom"
@@ -185,7 +185,7 @@ def test_paginator_first_no_results() -> None:
     assert paginator.count() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_first_no_results() -> None:
     async def fetch(_: dict[str, Any]) -> ListResult[Work]:
         meta = Meta(
@@ -198,7 +198,7 @@ async def test_async_paginator_first_no_results() -> None:
     assert await paginator.count() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_max_results_iter() -> None:
     total = 5
 
@@ -231,7 +231,7 @@ def test_paginator_page_increment_and_all() -> None:
     assert [w.id for w in items] == ["W0", "W1", "W2", "W3", "W4"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_pages_page_increment() -> None:
     """Async paginator uses page numbers when no cursor is returned."""
     total = 5
@@ -249,7 +249,7 @@ async def test_async_paginator_pages_page_increment() -> None:
     assert len(pages) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_paginator_gather_respects_max_results() -> None:
     """gather stops when reaching ``max_results``."""
     total = 10

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -22,7 +22,7 @@ def test_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not limiter.try_acquire()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limiter() -> None:
     limiter = AsyncRateLimiter(rate=1, burst=1, buffer=0)
     assert await limiter.acquire() == 0
@@ -48,7 +48,7 @@ def test_rate_limited_decorator(monkeypatch: pytest.MonkeyPatch) -> None:
     assert calls[0] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limited_decorator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -106,7 +106,7 @@ def test_sliding_window_rate_limiter_clean(
     assert wait_after == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_rate_limiter_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -31,7 +31,7 @@ def test_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     attempts: list[int] = []
 
@@ -68,7 +68,7 @@ def test_retry_config_wait_strategy() -> None:
     assert isinstance(strategy, type(wait_exponential()))
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_retry_handler_should_retry_and_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -110,7 +110,7 @@ def test_with_retry_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -149,7 +149,7 @@ def test_with_retry_default_config(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(attempts) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_async_with_retry_default_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- move Iterator import under `TYPE_CHECKING`
- keep runtime imports for pydantic model rebuild with noqa annotations
- apply Ruff formatting across repo
- update tests to use `@pytest.fixture()` style

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684880f0d2dc832ba8b1ebffd5ea98f2