### PR TITLE
Refactor utils and pagination

### DIFF
--- a/openalex/utils/common.py
+++ b/openalex/utils/common.py
@@ -28,8 +28,8 @@ def is_openalex_id(value: str, prefix: str = OPENALEX_ID_PREFIX) -> bool:
 
 
 def ensure_prefix(value: str, prefix: str) -> str:
-    """Ensure ``value`` starts with ``prefix``."""
-    return value if value.startswith(prefix) else f"{prefix}{value}"
+    """Return ``value`` with ``prefix`` if missing."""
+    return value if value.startswith(prefix) else prefix + value
 
 
 def empty_list_result() -> ListResult[Any]:

--- a/openalex/utils/params.py
+++ b/openalex/utils/params.py
@@ -80,9 +80,10 @@ def flatten_filter_dict(
             nested = flatten_filter_dict(value, full_key, ",")
             if nested:
                 parts.append(nested)
-        else:
-            serialized = serialize_filter_value(value)
-            parts.append(f"{full_key}:{serialized}")
+            continue
+
+        serialized = serialize_filter_value(value)
+        parts.append(f"{full_key}:{serialized}")
 
     return logical.join(parts)
 
@@ -109,10 +110,9 @@ def serialize_params(params: dict[str, Any]) -> dict[str, str]:
         elif key == "select" and isinstance(value, list):
             serialized["select"] = ",".join(value)
         elif value is not None:
-            if isinstance(value, bool):
-                serialized[key] = str(value).lower()
-            else:
-                serialized[key] = str(value)
+            serialized[key] = (
+                str(value).lower() if isinstance(value, bool) else str(value)
+            )
 
     return serialized
 


### PR DESCRIPTION
## Summary
- refactor pagination utilities
- tweak dataclasses for query logical expressions
- clean up rate limiting and helper functions
- simplify parameter serialization
- document prefix helper

## Testing
- `ruff format .`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684887e85c80832bb252a7614365fe86