### PR TITLE
Remove emojis and unicode escapes from docs

### DIFF
--- a/docs/authors/README.md
+++ b/docs/authors/README.md
@@ -2,7 +2,7 @@
 description: People who create works
 ---
 
-# \ud83d\udc69 Authors
+# Authors
 
 Authors are people who create works. You can access authors in the OpenAlex Python client like this:
 

--- a/docs/authors/filter-authors.md
+++ b/docs/authors/filter-authors.md
@@ -15,7 +15,7 @@ print(f"Total authors with ORCID: {results.meta.count:,}")  # e.g., 12,345,678
 print(f"Showing first {len(results.results)} authors")  # 25
 ```
 
-\ud83d\udca1 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Understanding filters vs. results
 

--- a/docs/authors/get-a-single-author.md
+++ b/docs/authors/get-a-single-author.md
@@ -36,7 +36,7 @@ for author in multiple_authors.results:
     print(f"- {author.display_name} ({author.works_count} works)")
 ```
 
-\ud83d\udca1 Authors are also available via an alias: `People()` works the same as `Authors()`
+Authors are also available via an alias: `People()` works the same as `Authors()`
 
 ## External IDs
 

--- a/docs/authors/group-authors.md
+++ b/docs/authors/group-authors.md
@@ -20,7 +20,7 @@ for group in continent_stats.group_by:
     print(f"    ({percentage:.1f}% of all authors)")
 ```
 
-\ud83d\udca1 **Key point**: `group_by()` returns COUNTS, not the actual authors. This is much more efficient than trying to fetch millions of author records!
+**Key point**: `group_by()` returns COUNTS, not the actual authors. This is much more efficient than trying to fetch millions of author records!
 
 ## Understanding group_by results
 

--- a/docs/authors/search-authors.md
+++ b/docs/authors/search-authors.md
@@ -34,7 +34,7 @@ tarrago2 = Authors().search("David Tarrag\u00f3").get()
 # When searching with diacritics, those versions are prioritized
 ```
 
-\ud83d\udca1 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/concepts/filter-concepts.md
+++ b/docs/concepts/filter-concepts.md
@@ -25,7 +25,7 @@ for concept in results.results[:5]:
     print(f"  Works: {concept.works_count:,}")
 ```
 
-💡 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Concepts attribute filters
 

--- a/docs/concepts/group-concepts.md
+++ b/docs/concepts/group-concepts.md
@@ -23,7 +23,7 @@ for group in level_stats.group_by:
     print(f"  Level {group.key}: {group.count:,} concepts")
 ```
 
-💡 **Key point**: `group_by()` returns COUNTS, not the actual concepts. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual concepts. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/concepts/search-concepts.md
+++ b/docs/concepts/search-concepts.md
@@ -42,7 +42,7 @@ ai_results = Concepts().search("AI").get()
 # May find "Artificial Intelligence", "AI applications", etc.
 ```
 
-💡 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/funders/filter-funders.md
+++ b/docs/funders/filter-funders.md
@@ -20,7 +20,7 @@ for funder in results.results[:5]:
     print(f"  Grants: {funder.grants_count:,}")
 ```
 
-💡 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Funders attribute filters
 

--- a/docs/funders/group-funders.md
+++ b/docs/funders/group-funders.md
@@ -18,7 +18,7 @@ for group in country_stats.group_by[:20]:
     print(f"  {group.key}: {group.count:,} funders")
 ```
 
-💡 **Key point**: `group_by()` returns COUNTS, not the actual funders. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual funders. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/funders/search-funders.md
+++ b/docs/funders/search-funders.md
@@ -38,7 +38,7 @@ science_results = Funders().search("science foundation").get()
 # Finds "National Science Foundation", "Swiss National Science Foundation", etc.
 ```
 
-💡 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/institutions/filter-institutions.md
+++ b/docs/institutions/filter-institutions.md
@@ -19,7 +19,7 @@ for inst in results.results[:5]:
     print(f"- {inst.display_name} ({inst.type})")
 ```
 
-💡 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Institutions attribute filters
 

--- a/docs/institutions/group-institutions.md
+++ b/docs/institutions/group-institutions.md
@@ -18,7 +18,7 @@ for group in country_stats.group_by[:20]:
     print(f"  {group.key}: {group.count:,} institutions")
 ```
 
-💡 **Key point**: `group_by()` returns COUNTS, not the actual institutions. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual institutions. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/institutions/search-institutions.md
+++ b/docs/institutions/search-institutions.md
@@ -36,7 +36,7 @@ stanford_results = Institutions().search("Stanford").get()
 # Finds "Stanford University", "Stanford Medicine", etc.
 ```
 
-💡 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/publishers/README.md
+++ b/docs/publishers/README.md
@@ -2,7 +2,7 @@
 description: Companies and organizations that distribute works
 ---
 
-# \ud83c\udfe2 Publishers
+# Publishers
 
 Publishers are companies and organizations that distribute journal articles, books, and theses. OpenAlex indexes about 10,000 publishers. You can access publishers in the Python client like this:
 

--- a/docs/publishers/filter-publishers.md
+++ b/docs/publishers/filter-publishers.md
@@ -19,7 +19,7 @@ for pub in results.results[:5]:
     print(f"- {pub.display_name}")
 ```
 
-\ud83d\udca1 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Publishers attribute filters
 

--- a/docs/publishers/group-publishers.md
+++ b/docs/publishers/group-publishers.md
@@ -18,7 +18,7 @@ for group in country_stats.group_by[:10]:  # Top 10 countries
     print(f"  {group.key}: {group.count:,} publishers")
 ```
 
-\ud83d\udca1 **Key point**: `group_by()` returns COUNTS, not the actual publishers. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual publishers. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/publishers/search-publishers.md
+++ b/docs/publishers/search-publishers.md
@@ -33,7 +33,7 @@ elsevier_results = Publishers().search("elsevier").get()
 # - Publishers with "\u0627\u0644\u0633\u0641\u06cc\u0631" (Arabic for Elsevier) in alternate_titles
 ```
 
-\ud83d\udca1 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -2,7 +2,7 @@
 description: Journals and repositories that host works
 ---
 
-# 📚 Sources
+# Sources
 
 Sources are where works are hosted. OpenAlex indexes about 249,000 sources. There are several types, including journals, conferences, preprint repositories, and institutional repositories.
 

--- a/docs/sources/filter-sources.md
+++ b/docs/sources/filter-sources.md
@@ -19,7 +19,7 @@ for source in results.results[:5]:
     print(f"- {source.display_name}: {source.issn_l}")
 ```
 
-💡 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Sources attribute filters
 

--- a/docs/sources/get-a-single-source.md
+++ b/docs/sources/get-a-single-source.md
@@ -39,7 +39,7 @@ for src in multiple_sources.results:
     print(f"  Open Access: {src.is_oa}")
 ```
 
-💡 **Tip**: Sources are also available via an alias:
+**Tip**: Sources are also available via an alias:
 ```python
 from openalex import Journals
 journals = Journals()  # Same as Sources()

--- a/docs/sources/group-sources.md
+++ b/docs/sources/group-sources.md
@@ -18,7 +18,7 @@ for group in publisher_stats.group_by[:20]:
     print(f"  {group.key}: {group.count:,} sources")
 ```
 
-💡 **Key point**: `group_by()` returns COUNTS, not the actual sources. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual sources. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/sources/search-sources.md
+++ b/docs/sources/search-sources.md
@@ -39,7 +39,7 @@ plos_results = Sources().search("PLoS").get()
 # Finds "PLOS ONE", "PLOS Biology", etc.
 ```
 
-💡 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -2,7 +2,7 @@
 description: Topics assigned to works
 ---
 
-# \ud83d\udca1 Topics
+# Topics
 
 Works in OpenAlex are tagged with Topics using an automated system that takes into account the available information about the work, including title, abstract, source (journal) name, and citations. There are around 4,500 Topics. Works are assigned topics using a model that assigns scores for each topic for a work. The highest-scoring topic is that work's [`primary_topic`](../works/work-object/#primary_topic). We also provide additional highly ranked topics for works, in [Work.topics](../works/work-object/README.md#topics).
 

--- a/docs/topics/filter-topics.md
+++ b/docs/topics/filter-topics.md
@@ -20,7 +20,7 @@ for topic in results.results[:5]:
     print(f"  Works: {topic.works_count:,}")
 ```
 
-💡 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Topics attribute filters
 

--- a/docs/topics/group-topics.md
+++ b/docs/topics/group-topics.md
@@ -18,7 +18,7 @@ for group in domain_stats.group_by:
     print(f"  Domain {group.key}: {group.count:,} topics")
 ```
 
-💡 **Key point**: `group_by()` returns COUNTS, not the actual topics. This is efficient for analytics.
+**Key point**: `group_by()` returns COUNTS, not the actual topics. This is efficient for analytics.
 
 ## Understanding group_by results
 

--- a/docs/topics/search-topics.md
+++ b/docs/topics/search-topics.md
@@ -38,7 +38,7 @@ climate_results = Topics().search("climate change").get()
 # Finds topics about climate, global warming, environmental change, etc.
 ```
 
-💡 Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
+Read more about search relevance, stemming, and boolean searches in the [search documentation](../../how-to-use-the-api/get-lists-of-entities/search-entities.md).
 
 ## Search a specific field
 

--- a/docs/works/README.md
+++ b/docs/works/README.md
@@ -2,7 +2,7 @@
 description: Journal articles, books, datasets, and theses
 ---
 
-# \ud83d\udcc4 Works
+# Works
 
 Works are scholarly documents like journal articles, books, datasets, and theses. OpenAlex indexes over 240M works, with about 50,000 added daily. You can access works in the OpenAlex Python client like this:
 

--- a/docs/works/filter-works.md
+++ b/docs/works/filter-works.md
@@ -15,7 +15,7 @@ print(f"Total works from 2020: {results.meta.count:,}")  # e.g., 4,567,890
 print(f"Showing first {len(results.results)} works")  # 25
 ```
 
-\ud83d\udca1 Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
+Remember: `.filter()` builds the query, `.get()` executes it and returns one page of results.
 
 ## Understanding filters vs. results
 

--- a/docs/works/group-works.md
+++ b/docs/works/group-works.md
@@ -30,7 +30,7 @@ Open Access statistics for all works in OpenAlex:
   closed: 197,456,789 works (80.5% of all works)
 ```
 
-\ud83d\udca1 **Key point**: `group_by()` returns COUNTS, not the actual works. This is much more efficient than trying to fetch millions of works!
+**Key point**: `group_by()` returns COUNTS, not the actual works. This is much more efficient than trying to fetch millions of works!
 
 ## Understanding group_by results
 

--- a/docs/works/search-works.md
+++ b/docs/works/search-works.md
@@ -22,7 +22,7 @@ for i, work in enumerate(results.results[:5], 1):
 
 Fulltext search is available for a subset of works, see `Work.has_fulltext` for more details.
 
-\ud83d\udca1 Search uses relevance ranking, stemming (e.g., "running" matches "run"), and removes common words.
+Search uses relevance ranking, stemming (e.g., "running" matches "run"), and removes common words.
 
 ## Search a specific field
 


### PR DESCRIPTION
## Summary
- strip emoji characters from documentation headers and notes
- drop unicode escapes like `\ud83d\udca1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488ee44e74832bb5646ccab3855980