### PR TITLE
Add missing fields to Work model

### DIFF
--- a/openalex/models/__init__.py
+++ b/openalex/models/__init__.py
@@ -37,6 +37,7 @@ from .work import (
     Authorship,
     Biblio,
     CitationNormalizedPercentile,
+    CitedByPercentileYear,
     DehydratedAuthor,
     DehydratedConcept,
     DehydratedInstitution,
@@ -50,6 +51,7 @@ from .work import (
     OpenAccessStatus,
     SustainableDevelopmentGoal,
     Work,
+    WorkAffiliation,
     WorkIds,
     WorkType,
 )
@@ -66,6 +68,7 @@ __all__ = [
     "BaseFilter",
     "Biblio",
     "CitationNormalizedPercentile",
+    "CitedByPercentileYear",
     "Concept",
     "ConceptAncestor",
     "ConceptIds",
@@ -116,6 +119,7 @@ __all__ = [
     "TopicIds",
     "TopicLevel",
     "Work",
+    "WorkAffiliation",
     "WorkIds",
     "WorkType",
 ]

--- a/openalex/models/work.py
+++ b/openalex/models/work.py
@@ -11,7 +11,9 @@ from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 from ..utils.text import invert_abstract
 
 __all__ = [
+    "CitedByPercentileYear",
     "Work",
+    "WorkAffiliation",
     "WorkIds",
     "WorkType",
     "WorksFilter",
@@ -197,12 +199,28 @@ class SustainableDevelopmentGoal(OpenAlexBase):
     score: float | None = None
 
 
+class WorkAffiliation(OpenAlexBase):
+    """Author affiliation details within a work."""
+
+    raw_affiliation_string: str | None = None
+    institution_ids: list[str] = Field(default_factory=list)
+
+
+class CitedByPercentileYear(OpenAlexBase):
+    """Citation percentile year range."""
+
+    min: int | None = None
+    max: int | None = None
+
+
 class WorkIds(OpenAlexBase):
     """External identifiers for a work."""
 
     openalex: str | None = None
     doi: HttpUrl | None = None
     pmid: str | None = None
+    pmcid: str | None = None
+    mag: str | None = None
 
 
 class Authorship(OpenAlexBase):
@@ -215,6 +233,7 @@ class Authorship(OpenAlexBase):
     is_corresponding: bool | None = None
     raw_author_name: str | None = None
     raw_affiliation_strings: list[str] = Field(default_factory=list)
+    affiliations: list[WorkAffiliation] = Field(default_factory=list)
 
 
 class Work(OpenAlexEntity):
@@ -235,6 +254,7 @@ class Work(OpenAlexEntity):
     corresponding_author_ids: list[str] = Field(default_factory=list)
     corresponding_institution_ids: list[str] = Field(default_factory=list)
     countries_distinct_count: int | None = None
+    institutions_distinct_count: int | None = None
     concepts: list[DehydratedConcept] = Field(default_factory=list)
     primary_topic: DehydratedTopic | None = None
     topics: list[DehydratedTopic] = Field(default_factory=list)
@@ -249,11 +269,16 @@ class Work(OpenAlexEntity):
     apc_list: APC | None = None
     apc_paid: APC | None = None
     grants: list[Grant] = Field(default_factory=list)
+    datasets: list[str] = Field(default_factory=list)
+    versions: list[str] = Field(default_factory=list)
     citation_normalized_percentile: CitationNormalizedPercentile | None = None
+    cited_by_percentile_year: CitedByPercentileYear | None = None
     counts_by_year: list[CountsByYear] = Field(default_factory=list)
     abstract_inverted_index: dict[str, list[int]] | None = None
     created_date: str | None = None
+    cited_by_api_url: str | None = None
     ids: WorkIds | None = None
+    institution_assertions: list[dict[str, Any]] = Field(default_factory=list)
     referenced_works: list[str] = Field(default_factory=list)
     referenced_works_count: int | None = None
     related_works: list[str] = Field(default_factory=list)
@@ -517,5 +542,7 @@ APC.model_rebuild()
 Biblio.model_rebuild()
 CitationNormalizedPercentile.model_rebuild()
 SustainableDevelopmentGoal.model_rebuild()
+WorkAffiliation.model_rebuild()
+CitedByPercentileYear.model_rebuild()
 Work.model_rebuild()
 Ngram.model_rebuild()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def mock_work_response() -> dict[str, Any]:
         "cited_by_count": 50000,
         "is_retracted": False,
         "is_paratext": False,
+        "institution_assertions": [],
         "open_access": {
             "is_oa": True,
             "oa_status": "bronze",
@@ -60,6 +61,12 @@ def mock_work_response() -> dict[str, Any]:
                 ],
                 "countries": ["US"],
                 "is_corresponding": True,
+                "affiliations": [
+                    {
+                        "raw_affiliation_string": "Tulane University",
+                        "institution_ids": ["https://openalex.org/I456789"],
+                    }
+                ],
             }
         ],
         "counts_by_year": [
@@ -71,6 +78,8 @@ def mock_work_response() -> dict[str, Any]:
             "openalex": "https://openalex.org/W2741809807",
             "doi": "https://doi.org/10.1103/physrevlett.77.3865",
             "pmid": "https://pubmed.ncbi.nlm.nih.gov/10062328",
+            "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567",
+            "mag": "2741809807",
         },
     }
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -42,6 +42,7 @@ class TestWork:
             "cited_by_count": 50000,
             "is_retracted": False,
             "is_paratext": False,
+            "institution_assertions": [],
             "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W2741809807",
             "abstract_inverted_index": {
                 "Generalized": [0, 87],
@@ -132,15 +133,21 @@ class TestWork:
                             "lineage": ["https://openalex.org/I131249849"],
                         }
                     ],
-                    "countries": ["US"],
-                    "is_corresponding": True,
-                    "raw_author_name": "John P. Perdew",
-                    "raw_affiliation_strings": [
-                        "Department of Physics and Quantum Theory Group, Tulane University, New Orleans, Louisiana 70118"
-                    ],
-                },
-                {
-                    "author_position": "middle",
+                "countries": ["US"],
+                "is_corresponding": True,
+                "raw_author_name": "John P. Perdew",
+                "raw_affiliation_strings": [
+                    "Department of Physics and Quantum Theory Group, Tulane University, New Orleans, Louisiana 70118"
+                ],
+                "affiliations": [
+                    {
+                        "raw_affiliation_string": "Department of Physics and Quantum Theory Group, Tulane University, New Orleans, Louisiana 70118",
+                        "institution_ids": ["https://openalex.org/I131249849"],
+                    }
+                ],
+            },
+            {
+                "author_position": "middle",
                     "author": {
                         "id": "https://openalex.org/A5082186243",
                         "display_name": "Kieron Burke",
@@ -157,14 +164,20 @@ class TestWork:
                         }
                     ],
                     "countries": ["US"],
-                    "is_corresponding": False,
-                    "raw_author_name": "Kieron Burke",
-                    "raw_affiliation_strings": [
-                        "Department of Chemistry, Rutgers University, Camden, New Jersey 08102"
-                    ],
-                },
-                {
-                    "author_position": "last",
+                "is_corresponding": False,
+                "raw_author_name": "Kieron Burke",
+                "raw_affiliation_strings": [
+                    "Department of Chemistry, Rutgers University, Camden, New Jersey 08102"
+                ],
+                "affiliations": [
+                    {
+                        "raw_affiliation_string": "Department of Chemistry, Rutgers University, Camden, New Jersey 08102",
+                        "institution_ids": ["https://openalex.org/I131249849"],
+                    }
+                ],
+            },
+            {
+                "author_position": "last",
                     "author": {
                         "id": "https://openalex.org/A5100600542",
                         "display_name": "Matthias Ernzerhof",
@@ -181,14 +194,21 @@ class TestWork:
                         }
                     ],
                     "countries": ["CA"],
-                    "is_corresponding": False,
-                    "raw_author_name": "Matthias Ernzerhof",
-                    "raw_affiliation_strings": [
-                        "Département de Chimie, Université de Montréal, Montréal, Québec, Canada H3C 3J7"
-                    ],
-                },
+                "is_corresponding": False,
+                "raw_author_name": "Matthias Ernzerhof",
+                "raw_affiliation_strings": [
+                    "Département de Chimie, Université de Montréal, Montréal, Québec, Canada H3C 3J7"
+                ],
+                "affiliations": [
+                    {
+                        "raw_affiliation_string": "Département de Chimie, Université de Montréal, Montréal, Québec, Canada H3C 3J7",
+                        "institution_ids": ["https://openalex.org/I70931966"],
+                    }
+                ],
+            },
             ],
             "countries_distinct_count": 2,
+            "institutions_distinct_count": 3,
             "corresponding_author_ids": ["https://openalex.org/A5023888391"],
             "corresponding_institution_ids": [
                 "https://openalex.org/I131249849"
@@ -223,6 +243,7 @@ class TestWork:
                 "is_in_top_1_percent": True,
                 "is_in_top_10_percent": True,
             },
+            "cited_by_percentile_year": {"min": 99, "max": 100},
             "concepts": [
                 {
                     "id": "https://openalex.org/C71924100",
@@ -448,6 +469,8 @@ class TestWork:
                 "openalex": "https://openalex.org/W2741809807",
                 "doi": "https://doi.org/10.1103/physrevlett.77.3865",
                 "pmid": "https://pubmed.ncbi.nlm.nih.gov/10062328",
+                "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567",
+                "mag": "2741809807",
             },
             "indexed_in": ["crossref", "pubmed"],
             "ngrams_url": "https://api.openalex.org/works/W2741809807/ngrams",
@@ -478,6 +501,9 @@ class TestWork:
         assert work.citation_normalized_percentile.value == 0.999969
         assert work.citation_normalized_percentile.is_in_top_1_percent is True
         assert work.citation_normalized_percentile.is_in_top_10_percent is True
+        assert work.cited_by_percentile_year is not None
+        assert work.cited_by_percentile_year.min == 99
+        assert work.cited_by_percentile_year.max == 100
 
         # Open Access
         assert work.is_oa is True
@@ -496,6 +522,10 @@ class TestWork:
         assert work.biblio.issue == "18"
         assert work.biblio.first_page == "3865"
         assert work.biblio.last_page == "3868"
+
+        assert work.ids is not None
+        assert work.ids.pmcid == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567"
+        assert work.ids.mag == "2741809807"
 
     def test_authorship_details(
         self, comprehensive_work_data: dict[str, Any]
@@ -517,18 +547,25 @@ class TestWork:
         assert first_author.institutions[0].display_name == "Tulane University"
         assert first_author.countries == ["US"]
         assert first_author.raw_author_name == "John P. Perdew"
+        assert len(first_author.affiliations) == 1
+        assert (
+            first_author.affiliations[0].institution_ids[0]
+            == "https://openalex.org/I131249849"
+        )
 
         # Middle author
         middle_author = work.authorships[1]
         assert middle_author.author_position == "middle"
         assert middle_author.is_corresponding is False
         assert middle_author.author.orcid is None
+        assert len(middle_author.affiliations) == 1
 
         # Last author
         last_author = work.authorships[2]
         assert last_author.author_position == "last"
         assert last_author.author.display_name == "Matthias Ernzerhof"
         assert last_author.institutions[0].country_code == "CA"
+        assert len(last_author.affiliations) == 1
 
         # Check corresponding IDs
         assert work.corresponding_author_ids == [
@@ -538,6 +575,7 @@ class TestWork:
             "https://openalex.org/I131249849"
         ]
         assert work.countries_distinct_count == 2
+        assert work.institutions_distinct_count == 3
 
     def test_abstract_reconstruction(
         self, comprehensive_work_data: dict[str, Any]


### PR DESCRIPTION
## Summary
- extend Work model to support affiliations, citation percentiles and more ids
- update fixtures and tests to reflect real API responses
- export new classes in model package

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -k "not docs" -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4451f924832b9c79f7b3e67026a2