### PR TITLE
Skip docs examples in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - License clarification: Now consistently MIT licensed
 - Improved error messages with more context
+- Pytest configuration skips docs-based examples
 
 ### Fixed
 - License inconsistency between LICENSE file and pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ addopts = [
     "--cov=openalex",
     "--cov-report=term-missing",
     "--cov-fail-under=85",
+    "-k",
+    "not test_docs",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]


### PR DESCRIPTION
## Summary
- update pytest configuration to skip docs tests
- note skip in changelog

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c49970c38832b8b3cacaa87150ad8