### PR TITLE
Fix async pagination handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - License inconsistency between LICENSE file and pyproject.toml
+- AsyncQuery pagination now respects cursors and returns correct counts
 
 ## [0.1.0] - 2024-01-01
 


### PR DESCRIPTION
## Summary
- update async query pagination to honor cursors and per-page
- fix async tests to use cursor in mocks and reset cache manager
- ensure NotFoundError raised for 404 responses

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/behavior/test_async.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_684d35fbaf48832bbe6bcf155856a136