### PR TITLE
Fix slow rate limit test

### DIFF
--- a/tests/behavior/test_client.py
+++ b/tests/behavior/test_client.py
@@ -62,7 +62,10 @@ class TestOpenAlexClient:
         from openalex.client import OpenAlexClient
         from openalex.exceptions import RateLimitError
 
-        client = OpenAlexClient()
+        from openalex import OpenAlexConfig
+
+        config = OpenAlexConfig(max_retries=1)
+        client = OpenAlexClient(config)
 
         with patch("httpx.Client.request") as mock_request:
             mock_request.return_value = mock_response(


### PR DESCRIPTION
## Summary
- prevent long sleep when testing rate limit handling

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest tests/behavior/test_client.py::TestOpenAlexClient::test_client_handles_rate_limit_response -vv`

------
https://chatgpt.com/codex/tasks/task_e_684d39f6d5f0832b8566397947f84f02