### PR TITLE
Fix retry limit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed caching logic to handle list queries and thread safety
 - License clarification: Now consistently MIT licensed
 - Request caching disabled by default
+- Verified caching behavior with updated tests
 
 ### Fixed
+- Retry logic now honors `max_retries` without exceeding the limit
 - Updated Pydantic models for works and related entities to match OpenAlex data
   fixtures used in tests.
 - Expanded author model with topics, topic share, and ORCID validation.

--- a/openalex/client.py
+++ b/openalex/client.py
@@ -80,8 +80,11 @@ class OpenAlexClient:
         req_params = self._default_params(params)
 
         attempt = 0
+        # ``retry_max_attempts`` already represents the total number of attempts
+        # allowed (including the first request).  Do not add 1 here to avoid
+        # exceeding the configured retry limit.
         max_attempts = (
-            self.config.retry_max_attempts + 1 if self.config.retry_enabled else 1
+            self.config.retry_max_attempts if self.config.retry_enabled else 1
         )
         wait = self.config.retry_initial_wait
 

--- a/openalex/connection.py
+++ b/openalex/connection.py
@@ -156,8 +156,9 @@ class AsyncConnection:
         params: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> httpx.Response:
+        # ``retry_max_attempts`` already counts the first request; don't add one.
         max_attempts = (
-            self._config.retry_max_attempts + 1 if self._config.retry_enabled else 1
+            self._config.retry_max_attempts if self._config.retry_enabled else 1
         )
         attempt = 0
 

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 if TYPE_CHECKING:  # pragma: no cover
     import builtins
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
     from .models.work import Ngram
     from .query import AsyncQuery
@@ -299,8 +298,7 @@ class BaseEntity(Generic[T, F]):
         """Iterate over all results for this entity."""
         paginator = self.paginate(**kwargs)
         for page in paginator:
-            for item in page.results:
-                yield item
+            yield from page.results
 
     def filter(self, **kwargs: Any) -> Query[T, F]:
         return self.query().filter(**kwargs)

--- a/openalex/query.py
+++ b/openalex/query.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 from pydantic import ValidationError
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
     from .config import OpenAlexConfig
     from .entities import AsyncBaseEntity, BaseEntity
@@ -257,8 +256,7 @@ class Query(Generic[T, F]):
         """Iterate over all results of the query."""
         paginator = self.paginate(per_page=per_page, max_results=max_results, **kwargs)
         for page in paginator:
-            for item in page.results:
-                yield item
+            yield from page.results
 
     def count(self) -> int:
         """Get count of results without fetching them."""

--- a/openalex/utils/retry.py
+++ b/openalex/utils/retry.py
@@ -281,7 +281,9 @@ def retry_with_rate_limit(func: Callable[..., T]) -> Callable[..., T]:
         if hasattr(self, "config"):
             config = self.config
             if getattr(config, "retry_enabled", True):
-                max_attempts = getattr(config, "retry_max_attempts", 5) + 1
+                # ``retry_max_attempts`` already includes the initial attempt,
+                # so use it directly without adding one.
+                max_attempts = getattr(config, "retry_max_attempts", 5)
             else:
                 max_attempts = 1
         attempt = 0


### PR DESCRIPTION
## Summary
- ensure retry limit logic doesn't exceed configured max
- adjust generator style and type-checking imports for Ruff
- document retry limit fix in CHANGELOG

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/behavior/test_cache.py -q`
- `pytest tests/behavior/test_client.py::TestOpenAlexClient::test_client_respects_retry_limit -q`


------
https://chatgpt.com/codex/tasks/task_e_684d437f0420832b8d0a3ed92a3e3005