### PR TITLE
Improve exception handling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed client-side trimming of ``counts_by_year`` lists; tests now reflect
   full data from fixtures.
 - Improved error messages with more context
+- Custom HTTP error handling now returns the correct exception types and
+  captures ``retry-after`` values without triggering long retries in tests
 - Updated Ruff configuration to ignore test-only warnings
 - Pytest configuration skips docs-based examples
 - Refactored test suite for maintainability and clarity


### PR DESCRIPTION
## Summary
- refine HTTP error parsing to avoid long retries
- ensure APIError keeps original message and details
- handle Retry-After headers correctly
- document fix in changelog

## Testing
- `ruff check . --fix`
- `mypy openalex`
- `pytest tests/behavior/test_exceptions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684d47b442d4832bb891e3bf83ec56fd