### PR TITLE
Ensure concept docs have standalone examples

### DIFF
--- a/docs/concepts/filter-concepts.md
+++ b/docs/concepts/filter-concepts.md
@@ -34,6 +34,7 @@ You can filter using these attributes of the [`Concept`](concept-object.md) obje
 ### Basic attribute filters
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Filter by cited_by_count
 highly_cited = Concepts().filter(cited_by_count=1000000).get()  # Exactly 1M
@@ -57,6 +58,7 @@ specific_ids = Concepts().filter(
 ### Hierarchical filters
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Filter by ancestors
 # Get all descendants of Computer Science (C41008148)
@@ -82,6 +84,7 @@ interdisciplinary = (
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Filter by h-index
 high_h_index = Concepts().filter_gt(summary_stats={"h_index": 200}).get()
 
@@ -110,6 +113,7 @@ These filters aren't attributes of the Concept object, but they're handy:
 ### Boolean filters
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Has Wikidata ID (currently all concepts have one)
 with_wikidata = Concepts().filter(has_wikidata=True).get()
@@ -123,6 +127,7 @@ print(f"Without Wikidata: {without_wikidata.meta.count:,}")  # Should be 0
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Search in display names
 ai_search = Concepts().filter(
     display_name={"search": "artificial intelligence"}
@@ -142,6 +147,7 @@ default_search = Concepts().filter(
 ### Combining filters (AND operations)
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # High-impact computer science concepts
 high_impact_cs = (
@@ -176,6 +182,7 @@ ml_concepts = (
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Concepts NOT under Computer Science
+from openalex import Concepts
 non_cs = Concepts().filter_not(ancestors={"id": "C41008148"}).get()
 
 # Non-root concepts
@@ -191,6 +198,7 @@ low_impact = Concepts().filter_not(
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Mid-level concepts (levels 2-4)
 mid_levels = (
     Concepts()
@@ -213,6 +221,7 @@ moderate_activity = (
 ### Example 1: Navigate concept tree
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def explore_concept_branch(concept_id, max_depth=3):
     """Explore a branch of the concept tree."""
@@ -250,6 +259,7 @@ explore_concept_branch("C41008148")
 ### Example 2: Find interdisciplinary concepts
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def find_interdisciplinary_concepts():
     """Find concepts that bridge multiple fields."""
@@ -281,6 +291,7 @@ find_interdisciplinary_concepts()
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 def analyze_research_trends(min_works=50000):
     """Find rapidly growing research areas."""
     
@@ -329,6 +340,7 @@ analyze_research_trends()
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 def find_similar_concepts(concept_id):
     """Find concepts similar to a given concept."""
     
@@ -369,6 +381,7 @@ Since there are ~65,000 concepts:
 4. **Use ancestors for branches**: Efficiently get entire subtrees
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Example: Efficiently analyze concept distribution
 def concept_distribution_summary():

--- a/docs/concepts/get-a-single-concept.md
+++ b/docs/concepts/get-a-single-concept.md
@@ -20,6 +20,9 @@ concept = Concepts().get("C71924100")
 That will return a [`Concept`](concept-object.md) object, describing everything OpenAlex knows about the concept with that ID:
 
 ```python
+from openalex import Concepts
+
+concept = Concepts()["C71924100"]
 # Access concept properties directly as Python attributes
 print(concept.id)  # "https://openalex.org/C71924100"
 print(concept.wikidata)  # "https://www.wikidata.org/wiki/Q11190" (canonical ID)
@@ -36,6 +39,7 @@ print(f"Level in hierarchy: {concept.level}")  # 0-5, where 0 is root
 You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Fetch multiple specific concepts in one API call
 concept_ids = ["C71924100", "C41008148", "C86803240"]
@@ -52,6 +56,7 @@ for c in multiple_concepts.results:
 You can look up concepts using external IDs such as a Wikidata ID:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Get concept by Wikidata ID (canonical external ID)
 medicine = Concepts()["wikidata:Q11190"]
@@ -73,6 +78,7 @@ Available external IDs for concepts are:
 You can use `select` to limit the fields that are returned in a concept object:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Fetch only specific fields to reduce response size
 minimal_concept = Concepts().select([

--- a/docs/concepts/get-lists-of-concepts.md
+++ b/docs/concepts/get-lists-of-concepts.md
@@ -30,6 +30,9 @@ The response contains:
 ## Understanding the results
 
 ```python
+from openalex import Concepts
+
+first_page = Concepts().get()
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Each result shows concept information
 for concept in first_page.results[:5]:  # First 5 concepts
@@ -75,6 +78,7 @@ print(f"Fetched all {len(all_concepts)} concepts")
 Get a random sample of concepts:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Get 10 random concepts
 random_sample = Concepts().sample(10).get(per_page=10)
@@ -96,6 +100,7 @@ level2_sample = (
 Limit the fields returned to improve performance:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Request only specific fields
 minimal_concepts = Concepts().select([
@@ -117,6 +122,7 @@ for concept in minimal_concepts.results:
 ### Example: Explore the concept tree
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def explore_concept_hierarchy():
     """Explore the 6-level concept hierarchy."""
@@ -146,6 +152,7 @@ explore_concept_hierarchy()
 ### Example: Analyze concept distribution by level
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_concept_levels():
     """Analyze how concepts are distributed across levels."""
@@ -174,6 +181,7 @@ analyze_concept_levels()
 ### Example: Find research hotspots
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def find_research_hotspots(min_works=10000):
     """Find highly active research concepts."""

--- a/docs/concepts/group-concepts.md
+++ b/docs/concepts/group-concepts.md
@@ -28,8 +28,8 @@ for group in level_stats.group_by:
 ## Understanding group_by results
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
-# The result structure is different from regular queries
 result = Concepts().group_by("level").get()
 
 print(result.results)  # Empty list - no individual concepts returned!
@@ -48,6 +48,7 @@ for group in result.group_by:
 ### Hierarchical grouping
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Group by level (0-5)
 by_level = Concepts().group_by("level").get()
@@ -66,6 +67,7 @@ by_wikidata = Concepts().group_by("has_wikidata").get()
 ### Activity-based grouping
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Works count distribution
 works_dist = Concepts().group_by("works_count").get()
@@ -90,6 +92,7 @@ impact_dist = Concepts().group_by("summary_stats.2yr_mean_citedness").get()
 Group_by becomes more insightful when combined with filters:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Level distribution for Computer Science descendants
 cs_levels = (
@@ -127,6 +130,7 @@ high_impact_levels = (
 You can group by two dimensions:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Level and ancestor combination
 level_ancestor = Concepts().group_by("level", "ancestors.id").get()
@@ -144,6 +148,7 @@ for group in level_ancestor.group_by[:20]:
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 def analyze_concept_hierarchy():
     """Comprehensive analysis of the concept tree structure."""
     
@@ -174,6 +179,7 @@ analyze_concept_hierarchy()
 ### Example 2: Research activity distribution
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_research_activity():
     """Analyze how research activity is distributed across concepts."""
@@ -221,6 +227,7 @@ analyze_research_activity()
 ### Example 3: Impact analysis
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_concept_impact():
     """Analyze impact metrics across the concept hierarchy."""
@@ -266,9 +273,9 @@ analyze_concept_impact()
 ### Example 4: Domain comparison
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def compare_domains():
-    """Compare research domains (root concepts)."""
     
     # Get all root concepts
     roots = Concepts().filter(level=0).get(per_page=25)
@@ -317,6 +324,7 @@ compare_domains()
 Control how results are ordered:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Default: sorted by count (descending)
 default_sort = Concepts().group_by("level").get()

--- a/docs/concepts/search-concepts.md
+++ b/docs/concepts/search-concepts.md
@@ -29,6 +29,7 @@ for concept in results.results[:5]:
 The search checks multiple fields:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # This searches display_name AND description
 ml_results = Concepts().search("machine learning").get()
@@ -50,6 +51,7 @@ You can also use search as a filter:
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Search only in display_name
 name_only = Concepts().filter(
     display_name={"search": "medical"}
@@ -79,6 +81,7 @@ Create a fast type-ahead search experience:
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Get autocomplete suggestions
 suggestions = Concepts().autocomplete("comp")
 
@@ -112,6 +115,7 @@ Computational biology
 Search is most powerful when combined with filters:
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Search for AI concepts at specific levels
 ai_subfields = (
@@ -157,6 +161,7 @@ emerging = (
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 def search_in_domain(search_term, domain_concept_id):
     """Search for concepts within a specific domain."""
     
@@ -186,6 +191,7 @@ search_in_domain("therapy", "C71924100")
 ### Multi-level search
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 def hierarchical_search(search_term):
     """Search at different levels of the hierarchy."""
@@ -212,6 +218,7 @@ hierarchical_search("network")
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 def discover_related_concepts(concept_id):
     """Find concepts related to a given concept through various methods."""
     
@@ -254,6 +261,7 @@ discover_related_concepts("C154945302")  # Machine learning
 ### Finding interdisciplinary concepts
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Bioinformatics, computational biology, etc.
 bio_comp = (
@@ -283,6 +291,7 @@ env_econ = (
 ### Research trend discovery
 
 ```python
+from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Find emerging concepts with specific terms
 emerging_tech = (
@@ -314,6 +323,7 @@ climate_concepts = (
 
 ```python
 # ⚠️ DEPRECATED: Consider using Topics instead
+from openalex import Concepts
 # Example: Comprehensive concept search
 def comprehensive_search(search_terms, min_works=1000):
     """Search with multiple strategies."""


### PR DESCRIPTION
## Summary
- make all concept documentation examples self-contained
- add missing imports in code blocks

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d6ace8954832ba973e0dbcf2cf3b9