### PR TITLE
Fix funder docs examples

### DIFF
--- a/docs/funders/filter-funders.md
+++ b/docs/funders/filter-funders.md
@@ -29,6 +29,7 @@ You can filter using these attributes of the [`Funder`](funder-object.md) object
 ### Basic attribute filters
 
 ```python
+from openalex import Funders
 # Filter by cited_by_count
 highly_cited = Funders().filter(cited_by_count=1000000).get()  # Exactly 1M
 very_highly_cited = Funders().filter_gt(cited_by_count=10000000).get()  # More than 10M
@@ -65,6 +66,7 @@ wiki_funder = Funders().filter(wikidata="Q390551").get()
 ### Summary statistics filters
 
 ```python
+from openalex import Funders
 # Filter by h-index
 high_h_index = Funders().filter_gt(summary_stats={"h_index": 500}).get()
 
@@ -93,6 +95,7 @@ These filters aren't attributes of the Funder object, but they're handy:
 ### Geographic convenience filters
 
 ```python
+from openalex import Funders
 # Filter by continent
 north_american = Funders().filter(continent="north_america").get()
 european = Funders().filter(continent="europe").get()
@@ -109,6 +112,7 @@ print(f"Global North funders: {global_north.meta.count:,}")
 ### Text search filters
 
 ```python
+from openalex import Funders
 # Search in display names
 health_search = Funders().filter(
     display_name={"search": "health"}
@@ -133,6 +137,7 @@ default_search = Funders().filter(
 ### Combining filters (AND operations)
 
 ```python
+from openalex import Funders
 # Large US government funders
 us_gov_funders = (
     Funders()
@@ -165,6 +170,7 @@ global_south_research = (
 ### NOT operations
 
 ```python
+from openalex import Funders
 # Funders NOT from the US
 non_us = Funders().filter_not(country_code="US").get()
 
@@ -177,6 +183,7 @@ low_grant_volume = Funders().filter_not(
 ### Range queries
 
 ```python
+from openalex import Funders
 # Mid-size funders (100-1000 grants)
 mid_size = (
     Funders()
@@ -199,6 +206,7 @@ moderate_impact = (
 ### Example 1: Find peer funders
 
 ```python
+from openalex import Funders
 def find_peer_funders(funder_id, radius=0.2):
     """Find funders similar to a given funder."""
     # First get the reference funder
@@ -231,6 +239,7 @@ for funder in nsf_peers.results:
 ### Example 2: Regional funding analysis
 
 ```python
+from openalex import Funders
 def analyze_regional_funding():
     """Compare funding landscapes across regions."""
     
@@ -266,6 +275,7 @@ analyze_regional_funding()
 ### Example 3: Funding specialization
 
 ```python
+from openalex import Funders
 def find_specialized_funders(search_term, min_focus_score=0.8):
     """Find funders specialized in a particular area."""
     
@@ -297,6 +307,7 @@ find_specialized_funders("climate")
 ### Example 4: Multi-role organizations
 
 ```python
+from openalex import Funders
 def find_multi_role_organizations():
     """Find organizations that are funders, institutions, and/or publishers."""
     
@@ -337,6 +348,7 @@ Since there are only ~32,000 funders:
 4. **Consider caching**: The funder list changes slowly
 
 ```python
+from openalex import Funders
 # Example: Efficiently analyze global funding distribution
 def global_funding_summary():
     # Use group_by instead of fetching all funders

--- a/docs/funders/get-a-single-funder.md
+++ b/docs/funders/get-a-single-funder.md
@@ -15,20 +15,26 @@ funder = Funders().get("F4320332161")
 That will return a [`Funder`](funder-object.md) object, describing everything OpenAlex knows about the funder with that ID:
 
 ```python
-# Access funder properties directly as Python attributes
-print(funder.id)  # "https://openalex.org/F4320332161"
-print(funder.display_name)  # "National Institutes of Health"
-print(funder.alternate_titles)  # ["US National Institutes of Health", "Institutos Nacionales de la Salud", "NIH"]
-print(funder.country_code)  # "US"
-print(funder.description)  # "medical research organization in the United States"
-print(funder.works_count)  # Number of works funded
-print(funder.grants_count)  # Number of grants
-print(funder.cited_by_count)  # Total citations to funded works
+from openalex import Funders
+
+funder = Funders()["F4320332161"]  # NIH
+print(f"Name: {funder.display_name}")
+print(f"OpenAlex: {funder.id}")
+print(f"ROR: {funder.ror}")
+print(f"Wikidata: {funder.ids.wikidata}")
+print(f"Crossref: {funder.ids.crossref}")
+print(f"DOI: {funder.ids.doi}")
+print(f"Country: {funder.country_code}")
+print(f"Grants: {funder.grants_count:,}")
+print(f"Works funded: {funder.works_count:,}")
+print(f"Citations: {funder.cited_by_count:,}")
 ```
 
 You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
 
 ```python
+from openalex import Funders
+
 # Fetch multiple specific funders in one API call
 funder_ids = ["F4320332161", "F4320321001", "F4320306076"]
 multiple_funders = Funders().filter(openalex=funder_ids).get()
@@ -44,8 +50,10 @@ for fund in multiple_funders.results:
 
 You can look up funders using external IDs such as a Wikidata ID:
 
+
 ```python
 # Get funder by Wikidata ID
+from openalex import Funders
 nih = Funders()["wikidata:Q390551"]
 
 # Get funder by ROR ID
@@ -70,9 +78,11 @@ Available external IDs for funders are:
 
 ## Select fields
 
+
 You can use `select` to limit the fields that are returned in a funder object:
 
 ```python
+from openalex import Funders
 # Fetch only specific fields to reduce response size
 minimal_funder = Funders().select([
     "id", 

--- a/docs/funders/get-lists-of-funders.md
+++ b/docs/funders/get-lists-of-funders.md
@@ -25,9 +25,12 @@ The response contains:
 ## Understanding the results
 
 ```python
-# Each result shows funder information
-for funder in first_page.results[:5]:  # First 5 funders
-    print(f"\n{funder.display_name}")
+from openalex import Funders
+
+first_page = Funders().get()
+for funder in first_page.results[:5]:
+    print(f"
+{funder.display_name}")
     print(f"  Country: {funder.country_code}")
     print(f"  Grants: {funder.grants_count:,}")
     print(f"  Funded works: {funder.works_count:,}")
@@ -41,6 +44,8 @@ for funder in first_page.results[:5]:  # First 5 funders
 You can control pagination and sorting:
 
 ```python
+from openalex import Funders
+
 # Get a specific page with custom page size
 page2 = Funders().get(per_page=50, page=2)
 # This returns funders 51-100
@@ -68,6 +73,8 @@ print(f"Fetched all {len(all_funders)} funders")
 Get a random sample of funders:
 
 ```python
+from openalex import Funders
+
 # Get 10 random funders
 random_sample = Funders().sample(10).get(per_page=10)
 
@@ -87,8 +94,10 @@ us_funder_sample = (
 
 Limit the fields returned to improve performance:
 
+
 ```python
 # Request only specific fields
+from openalex import Funders
 minimal_funders = Funders().select([
     "id", 
     "display_name",
@@ -108,6 +117,8 @@ for funder in minimal_funders.results:
 ### Example: Analyze funding landscape
 
 ```python
+from openalex import Funders
+
 # Get major funding agencies
 major_funders = (
     Funders()
@@ -127,6 +138,7 @@ for i, funder in enumerate(major_funders.results, 1):
 ### Example: Geographic distribution
 
 ```python
+from openalex import Funders
 # Analyze funders by region
 def analyze_funding_by_region():
     regions = {
@@ -159,6 +171,7 @@ analyze_funding_by_region()
 ### Example: Funding impact analysis
 
 ```python
+from openalex import Funders
 # Find high-impact funders
 def find_high_impact_funders(min_h_index=200):
     """Find funders supporting high-impact research."""

--- a/docs/funders/group-funders.md
+++ b/docs/funders/group-funders.md
@@ -23,6 +23,7 @@ for group in country_stats.group_by[:20]:
 ## Understanding group_by results
 
 ```python
+from openalex import Funders
 # The result structure is different from regular queries
 result = Funders().group_by("continent").get()
 
@@ -41,6 +42,7 @@ for group in result.group_by:
 ### Basic grouping
 
 ```python
+from openalex import Funders
 # Group by country
 by_country = Funders().group_by("country_code").get()
 # See which countries have the most funders
@@ -65,6 +67,7 @@ citation_dist = Funders().group_by("cited_by_count").get()
 ### Research metrics grouping
 
 ```python
+from openalex import Funders
 # H-index distribution
 h_index_dist = Funders().group_by("summary_stats.h_index").get()
 
@@ -83,6 +86,7 @@ productivity_dist = Funders().group_by("works_count").get()
 Group_by becomes more insightful when combined with filters:
 
 ```python
+from openalex import Funders
 # Country distribution for large funders only
 large_funder_countries = (
     Funders()
@@ -124,6 +128,7 @@ active_funders_grants = (
 You can group by two dimensions:
 
 ```python
+from openalex import Funders
 # Country and grant volume
 country_grants = Funders().group_by("country_code", "grants_count").get()
 
@@ -142,6 +147,7 @@ for group in country_grants.group_by[:20]:
 ### Example 1: Global funding landscape
 
 ```python
+from openalex import Funders
 def analyze_global_funding_landscape():
     """Analyze the global distribution of research funders."""
     
@@ -181,6 +187,7 @@ analyze_global_funding_landscape()
 ### Example 2: Funding concentration analysis
 
 ```python
+from openalex import Funders
 def analyze_funding_concentration():
     """Analyze how concentrated research funding is."""
     
@@ -238,6 +245,7 @@ analyze_funding_concentration()
 ### Example 3: Funding impact tiers
 
 ```python
+from openalex import Funders
 def analyze_funding_impact_tiers():
     """Group funders into impact tiers based on h-index."""
     
@@ -284,6 +292,7 @@ analyze_funding_impact_tiers()
 ### Example 4: Funding ecosystem comparison
 
 ```python
+from openalex import Funders
 def compare_funding_ecosystems():
     """Compare funding characteristics across regions."""
     
@@ -340,6 +349,7 @@ compare_funding_ecosystems()
 Control how results are ordered:
 
 ```python
+from openalex import Funders
 # Default: sorted by count (descending)
 default_sort = Funders().group_by("country_code").get()
 # US first (most funders), then CN, GB, etc.

--- a/docs/funders/search-funders.md
+++ b/docs/funders/search-funders.md
@@ -25,6 +25,7 @@ for funder in results.results[:5]:
 The search checks multiple fields:
 
 ```python
+from openalex import Funders
 # This searches display_name, alternate_titles, AND description
 nih_results = Funders().search("NIH").get()
 
@@ -45,6 +46,7 @@ Read more about search relevance, stemming, and boolean searches in the [search 
 You can also use search as a filter:
 
 ```python
+from openalex import Funders
 # Search only in display_name
 name_only = Funders().filter(
     display_name={"search": "florida"}
@@ -79,6 +81,7 @@ Available search fields:
 Create a fast type-ahead search experience:
 
 ```python
+from openalex import Funders
 # Get autocomplete suggestions
 suggestions = Funders().autocomplete("national sci")
 
@@ -112,6 +115,7 @@ Swiss National Science Foundation
 Search is most powerful when combined with filters:
 
 ```python
+from openalex import Funders
 # Search for US health-related funders
 us_health_funders = (
     Funders()
@@ -155,6 +159,7 @@ cancer_funders = (
 ### Finding government funders
 
 ```python
+from openalex import Funders
 def find_government_funders(country_code=None):
     """Find government funding agencies."""
     
@@ -183,6 +188,7 @@ find_government_funders("GB")
 ### Finding foundation funders
 
 ```python
+from openalex import Funders
 def find_foundations(focus_area=None):
     """Find private foundations and charities."""
     
@@ -213,6 +219,7 @@ find_foundations("education")
 ### International funder search
 
 ```python
+from openalex import Funders
 def search_international_funders(search_term):
     """Search for funders across multiple languages/variations."""
     
@@ -245,6 +252,7 @@ search_international_funders("Research")
 ### Finding funding opportunities by field
 
 ```python
+from openalex import Funders
 # Medical research funders
 medical_funders = (
     Funders()
@@ -273,6 +281,7 @@ env_funders = (
 ### Regional funder discovery
 
 ```python
+from openalex import Funders
 # Find funders in specific regions
 def find_regional_funders(region, min_grants=50):
     if region == "EU":
@@ -314,6 +323,7 @@ apac_funders = find_regional_funders("Asia-Pacific")
 5. **Use boolean operators**: "cancer AND research" for more specific results
 
 ```python
+from openalex import Funders
 # Example: Comprehensive funder search
 def comprehensive_funder_search(keywords, country=None, min_impact=None):
     """Search with multiple strategies."""


### PR DESCRIPTION
## Summary
- make funder docs examples self-contained with imports
- re-fetch funders for attribute access in examples
- adjust funder list examples for clarity

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest` *(fails: TestPaginationBehavior::test_async_paginator_gather)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c51a310832ba21a3ba55dc3d6ee