### PR TITLE
Make funder examples self contained

### DIFF
--- a/docs/funders/filter-funders.md
+++ b/docs/funders/filter-funders.md
@@ -29,6 +29,8 @@ You can filter using these attributes of the [`Funder`](funder-object.md) object
 ### Basic attribute filters
 
 ```python
+from openalex import Funders
+
 # Filter by cited_by_count
 highly_cited = Funders().filter(cited_by_count=1000000).get()  # Exactly 1M
 very_highly_cited = Funders().filter_gt(cited_by_count=10000000).get()  # More than 10M
@@ -42,8 +44,11 @@ major_funders = Funders().filter_gt(grants_count=1000).get()  # More than 1k gra
 minor_funders = Funders().filter_lt(grants_count=10).get()  # Fewer than 10 grants
 
 # Filter by country
-us_funders = Funders().filter(country_code="US").get()
-uk_funders = Funders().filter(country_code="GB").get()
+us_funders = Funders().filter(country_code="US")
+results = us_funders.get()
+print(f"US funders: {results.meta.count}")
+for funder in results.results[:5]:
+    print(f"- {funder.display_name}")
 
 # Multiple countries (OR operation)
 european_funders = Funders().filter(
@@ -65,6 +70,8 @@ wiki_funder = Funders().filter(wikidata="Q390551").get()
 ### Summary statistics filters
 
 ```python
+from openalex import Funders
+
 # Filter by h-index
 high_h_index = Funders().filter_gt(summary_stats={"h_index": 500}).get()
 
@@ -93,6 +100,8 @@ These filters aren't attributes of the Funder object, but they're handy:
 ### Geographic convenience filters
 
 ```python
+from openalex import Funders
+
 # Filter by continent
 north_american = Funders().filter(continent="north_america").get()
 european = Funders().filter(continent="europe").get()
@@ -109,6 +118,8 @@ print(f"Global North funders: {global_north.meta.count:,}")
 ### Text search filters
 
 ```python
+from openalex import Funders
+
 # Search in display names
 health_search = Funders().filter(
     display_name={"search": "health"}
@@ -199,6 +210,8 @@ moderate_impact = (
 ### Example 1: Find peer funders
 
 ```python
+from openalex import Funders
+
 def find_peer_funders(funder_id, radius=0.2):
     """Find funders similar to a given funder."""
     # First get the reference funder
@@ -231,6 +244,8 @@ for funder in nsf_peers.results:
 ### Example 2: Regional funding analysis
 
 ```python
+from openalex import Funders
+
 def analyze_regional_funding():
     """Compare funding landscapes across regions."""
     
@@ -266,6 +281,8 @@ analyze_regional_funding()
 ### Example 3: Funding specialization
 
 ```python
+from openalex import Funders
+
 def find_specialized_funders(search_term, min_focus_score=0.8):
     """Find funders specialized in a particular area."""
     
@@ -297,6 +314,8 @@ find_specialized_funders("climate")
 ### Example 4: Multi-role organizations
 
 ```python
+from openalex import Funders
+
 def find_multi_role_organizations():
     """Find organizations that are funders, institutions, and/or publishers."""
     
@@ -338,6 +357,8 @@ Since there are only ~32,000 funders:
 
 ```python
 # Example: Efficiently analyze global funding distribution
+from openalex import Funders
+
 def global_funding_summary():
     # Use group_by instead of fetching all funders
     by_country = Funders().group_by("country_code").get()

--- a/docs/funders/get-a-single-funder.md
+++ b/docs/funders/get-a-single-funder.md
@@ -15,20 +15,23 @@ funder = Funders().get("F4320332161")
 That will return a [`Funder`](funder-object.md) object, describing everything OpenAlex knows about the funder with that ID:
 
 ```python
-# Access funder properties directly as Python attributes
-print(funder.id)  # "https://openalex.org/F4320332161"
-print(funder.display_name)  # "National Institutes of Health"
-print(funder.alternate_titles)  # ["US National Institutes of Health", "Institutos Nacionales de la Salud", "NIH"]
-print(funder.country_code)  # "US"
-print(funder.description)  # "medical research organization in the United States"
-print(funder.works_count)  # Number of works funded
-print(funder.grants_count)  # Number of grants
-print(funder.cited_by_count)  # Total citations to funded works
+from openalex import Funders
+
+funder = Funders()["F4320332161"]  # NIH
+print(f"OpenAlex ID: {funder.id}")
+print(f"Name: {funder.display_name}")
+print(f"Country: {funder.country_code}")
+print(f"Description: {funder.description}")
+print(f"Total grants: {funder.grants_count:,}")
+print(f"Works funded: {funder.works_count:,}")
+print(f"Total citations: {funder.cited_by_count:,}")
 ```
 
 You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
 
 ```python
+from openalex import Funders
+
 # Fetch multiple specific funders in one API call
 funder_ids = ["F4320332161", "F4320321001", "F4320306076"]
 multiple_funders = Funders().filter(openalex=funder_ids).get()
@@ -45,6 +48,8 @@ for fund in multiple_funders.results:
 You can look up funders using external IDs such as a Wikidata ID:
 
 ```python
+from openalex import Funders
+
 # Get funder by Wikidata ID
 nih = Funders()["wikidata:Q390551"]
 
@@ -73,6 +78,8 @@ Available external IDs for funders are:
 You can use `select` to limit the fields that are returned in a funder object:
 
 ```python
+from openalex import Funders
+
 # Fetch only specific fields to reduce response size
 minimal_funder = Funders().select([
     "id", 

--- a/docs/funders/get-lists-of-funders.md
+++ b/docs/funders/get-lists-of-funders.md
@@ -25,7 +25,10 @@ The response contains:
 ## Understanding the results
 
 ```python
+from openalex import Funders
+
 # Each result shows funder information
+first_page = Funders().get()
 for funder in first_page.results[:5]:  # First 5 funders
     print(f"\n{funder.display_name}")
     print(f"  Country: {funder.country_code}")
@@ -41,6 +44,8 @@ for funder in first_page.results[:5]:  # First 5 funders
 You can control pagination and sorting:
 
 ```python
+from openalex import Funders
+
 # Get a specific page with custom page size
 page2 = Funders().get(per_page=50, page=2)
 # This returns funders 51-100
@@ -68,6 +73,8 @@ print(f"Fetched all {len(all_funders)} funders")
 Get a random sample of funders:
 
 ```python
+from openalex import Funders
+
 # Get 10 random funders
 random_sample = Funders().sample(10).get(per_page=10)
 
@@ -88,6 +95,8 @@ us_funder_sample = (
 Limit the fields returned to improve performance:
 
 ```python
+from openalex import Funders
+
 # Request only specific fields
 minimal_funders = Funders().select([
     "id", 
@@ -109,6 +118,7 @@ for funder in minimal_funders.results:
 
 ```python
 # Get major funding agencies
+from openalex import Funders
 major_funders = (
     Funders()
     .filter_gt(grants_count=1000)
@@ -128,6 +138,7 @@ for i, funder in enumerate(major_funders.results, 1):
 
 ```python
 # Analyze funders by region
+from openalex import Funders
 def analyze_funding_by_region():
     regions = {
         "North America": ["US", "CA"],
@@ -160,6 +171,7 @@ analyze_funding_by_region()
 
 ```python
 # Find high-impact funders
+from openalex import Funders
 def find_high_impact_funders(min_h_index=200):
     """Find funders supporting high-impact research."""
     

--- a/docs/funders/group-funders.md
+++ b/docs/funders/group-funders.md
@@ -24,6 +24,7 @@ for group in country_stats.group_by[:20]:
 
 ```python
 # The result structure is different from regular queries
+from openalex import Funders
 result = Funders().group_by("continent").get()
 
 print(result.results)  # Empty list - no individual funders returned!
@@ -41,6 +42,8 @@ for group in result.group_by:
 ### Basic grouping
 
 ```python
+from openalex import Funders
+
 # Group by country
 by_country = Funders().group_by("country_code").get()
 # See which countries have the most funders
@@ -65,6 +68,8 @@ citation_dist = Funders().group_by("cited_by_count").get()
 ### Research metrics grouping
 
 ```python
+from openalex import Funders
+
 # H-index distribution
 h_index_dist = Funders().group_by("summary_stats.h_index").get()
 
@@ -83,6 +88,8 @@ productivity_dist = Funders().group_by("works_count").get()
 Group_by becomes more insightful when combined with filters:
 
 ```python
+from openalex import Funders
+
 # Country distribution for large funders only
 large_funder_countries = (
     Funders()
@@ -142,6 +149,8 @@ for group in country_grants.group_by[:20]:
 ### Example 1: Global funding landscape
 
 ```python
+from openalex import Funders
+
 def analyze_global_funding_landscape():
     """Analyze the global distribution of research funders."""
     
@@ -181,6 +190,8 @@ analyze_global_funding_landscape()
 ### Example 2: Funding concentration analysis
 
 ```python
+from openalex import Funders
+
 def analyze_funding_concentration():
     """Analyze how concentrated research funding is."""
     
@@ -238,6 +249,8 @@ analyze_funding_concentration()
 ### Example 3: Funding impact tiers
 
 ```python
+from openalex import Funders
+
 def analyze_funding_impact_tiers():
     """Group funders into impact tiers based on h-index."""
     
@@ -284,6 +297,8 @@ analyze_funding_impact_tiers()
 ### Example 4: Funding ecosystem comparison
 
 ```python
+from openalex import Funders
+
 def compare_funding_ecosystems():
     """Compare funding characteristics across regions."""
     
@@ -340,6 +355,8 @@ compare_funding_ecosystems()
 Control how results are ordered:
 
 ```python
+from openalex import Funders
+
 # Default: sorted by count (descending)
 default_sort = Funders().group_by("country_code").get()
 # US first (most funders), then CN, GB, etc.

--- a/docs/funders/search-funders.md
+++ b/docs/funders/search-funders.md
@@ -25,6 +25,8 @@ for funder in results.results[:5]:
 The search checks multiple fields:
 
 ```python
+from openalex import Funders
+
 # This searches display_name, alternate_titles, AND description
 nih_results = Funders().search("NIH").get()
 
@@ -45,6 +47,8 @@ Read more about search relevance, stemming, and boolean searches in the [search 
 You can also use search as a filter:
 
 ```python
+from openalex import Funders
+
 # Search only in display_name
 name_only = Funders().filter(
     display_name={"search": "florida"}
@@ -79,6 +83,8 @@ Available search fields:
 Create a fast type-ahead search experience:
 
 ```python
+from openalex import Funders
+
 # Get autocomplete suggestions
 suggestions = Funders().autocomplete("national sci")
 
@@ -113,6 +119,7 @@ Search is most powerful when combined with filters:
 
 ```python
 # Search for US health-related funders
+from openalex import Funders
 us_health_funders = (
     Funders()
     .search("health")
@@ -155,6 +162,8 @@ cancer_funders = (
 ### Finding government funders
 
 ```python
+from openalex import Funders
+
 def find_government_funders(country_code=None):
     """Find government funding agencies."""
     
@@ -183,6 +192,8 @@ find_government_funders("GB")
 ### Finding foundation funders
 
 ```python
+from openalex import Funders
+
 def find_foundations(focus_area=None):
     """Find private foundations and charities."""
     
@@ -213,6 +224,8 @@ find_foundations("education")
 ### International funder search
 
 ```python
+from openalex import Funders
+
 def search_international_funders(search_term):
     """Search for funders across multiple languages/variations."""
     
@@ -274,6 +287,8 @@ env_funders = (
 
 ```python
 # Find funders in specific regions
+from openalex import Funders
+
 def find_regional_funders(region, min_grants=50):
     if region == "EU":
         results = (
@@ -315,6 +330,8 @@ apac_funders = find_regional_funders("Asia-Pacific")
 
 ```python
 # Example: Comprehensive funder search
+from openalex import Funders
+
 def comprehensive_funder_search(keywords, country=None, min_impact=None):
     """Search with multiple strategies."""
     


### PR DESCRIPTION
## Summary
- ensure each docs/funders example includes required imports
- re-fetch funder objects in every standalone code block
- show counts when filtering by country
- add top-level imports in grouping, search and listing docs

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d6b388500832b921d4fb901703c8a