### PR TITLE
Make publisher doc examples standalone

### DIFF
--- a/docs/publishers/filter-publishers.md
+++ b/docs/publishers/filter-publishers.md
@@ -28,6 +28,8 @@ You can filter using these attributes of the [`Publisher`](publisher-object.md) 
 ### Basic attribute filters
 
 ```python
+from openalex import Publishers
+
 # Filter by cited_by_count
 highly_cited = Publishers().filter(cited_by_count=1000000).get()  # Exactly 1M
 very_highly_cited = Publishers().filter_gt(cited_by_count=10000000).get()  # More than 10M
@@ -50,6 +52,8 @@ specific_ids = Publishers().filter(
 ### Geographic filters
 
 ```python
+from openalex import Publishers
+
 # Filter by country
 us_publishers = Publishers().filter(country_codes="US").get()
 uk_publishers = Publishers().filter(country_codes="GB").get()
@@ -63,6 +67,8 @@ european_publishers = Publishers().filter(
 ### Hierarchy filters
 
 ```python
+from openalex import Publishers
+
 # Find all subsidiaries of a publisher using lineage
 springer_nature_id = "P4310319965"
 springer_family = Publishers().filter(lineage=springer_nature_id).get()
@@ -81,6 +87,8 @@ wikidata_publisher = Publishers().filter(wikidata="Q746413").get()
 ### Summary statistics filters
 
 ```python
+from openalex import Publishers
+
 # Filter by h-index
 high_impact = Publishers().filter_gt(summary_stats={"h_index": 500}).get()
 
@@ -109,6 +117,8 @@ These filters aren't attributes of the Publisher object, but they're handy for c
 ### Geographic convenience filters
 
 ```python
+from openalex import Publishers
+
 # Filter by continent
 european_publishers = Publishers().filter(continent="europe").get()
 asian_publishers = Publishers().filter(continent="asia").get()
@@ -117,6 +127,8 @@ asian_publishers = Publishers().filter(continent="asia").get()
 ### Text search filters
 
 ```python
+from openalex import Publishers
+
 # Search in display names
 elsevier_search = Publishers().filter(
     display_name={"search": "elsevier"}
@@ -136,6 +148,8 @@ default_search = Publishers().filter(
 ### Combining filters (AND operations)
 
 ```python
+from openalex import Publishers
+
 # Large US publishers
 large_us_publishers = (
     Publishers()
@@ -158,6 +172,8 @@ european_elite = (
 ### NOT operations
 
 ```python
+from openalex import Publishers
+
 # Publishers NOT from the US
 non_us_publishers = Publishers().filter_not(country_codes="US").get()
 
@@ -168,6 +184,8 @@ subsidiaries = Publishers().filter_not(hierarchy_level=0).get()
 ### Range queries
 
 ```python
+from openalex import Publishers
+
 # Mid-size publishers (10k-100k works)
 mid_size = (
     Publishers()
@@ -190,6 +208,8 @@ moderate_impact = (
 ### Example 1: Analyze publisher families
 
 ```python
+from openalex import Publishers
+
 # Get a major publisher
 elsevier = Publishers().search("Elsevier BV").get().results[0]
 
@@ -206,6 +226,8 @@ for pub in elsevier_family.results:
 ### Example 2: Compare publishers by region
 
 ```python
+from openalex import Publishers
+
 # Get top publishers by continent
 def top_publishers_by_continent(continent, limit=5):
     return (
@@ -226,6 +248,8 @@ for continent in ["north_america", "europe", "asia"]:
 ### Example 3: Find university presses
 
 ```python
+from openalex import Publishers
+
 # University presses often have "University Press" in the name
 uni_presses = Publishers().search("University Press").get(per_page=50)
 
@@ -256,6 +280,8 @@ Since there are only ~10,000 publishers:
 
 ```python
 # Example: Get summary of all publishers efficiently
+from openalex import Publishers
+
 def get_publisher_summary():
     # Use group_by for statistics
     by_country = Publishers().group_by("country_codes").get()

--- a/docs/publishers/get-a-single-publisher.md
+++ b/docs/publishers/get-a-single-publisher.md
@@ -15,18 +15,25 @@ publisher = Publishers().get("P4310319965")
 That will return a [`Publisher`](publisher-object.md) object, describing everything OpenAlex knows about the publisher with that ID:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310319965"]  # Springer Nature
+
 # Access publisher properties directly as Python attributes
-print(publisher.id)  # "https://openalex.org/P4310319965"
-print(publisher.display_name)  # "Springer Nature"
-print(publisher.alternate_titles)  # List of alternate names
-print(publisher.hierarchy_level)  # 0 (top-level publisher)
-print(publisher.works_count)  # Number of works published
-print(publisher.cited_by_count)  # Total citations to their works
+print(publisher.id)
+print(publisher.display_name)
+print(publisher.alternate_titles)
+print(publisher.hierarchy_level)
+print(f"Works: {publisher.works_count:,}")
+print(f"Citations: {publisher.cited_by_count:,}")
 ```
 
 You can make up to 50 of these queries at once by requesting a list of entities and filtering on IDs:
 
 ```python
+
+from openalex import Publishers
+
 # Fetch multiple specific publishers in one API call
 publisher_ids = ["P4310319965", "P4310320990", "P4310319900"]
 multiple_publishers = Publishers().filter(openalex=publisher_ids).get()
@@ -42,6 +49,8 @@ You can look up publishers using external IDs such as a Wikidata ID:
 
 ```python
 # Get publisher by Wikidata ID
+from openalex import Publishers
+
 publisher = Publishers()["wikidata:Q1479654"]
 
 # Get publisher by ROR ID
@@ -64,9 +73,29 @@ You can use `select` to limit the fields that are returned in a publisher object
 
 ```python
 # Fetch only specific fields to reduce response size
+from openalex import Publishers
+
 minimal_publisher = Publishers().select(["id", "display_name", "works_count"]).get("P4310319965")
 
 # Now only the selected fields are populated
 print(minimal_publisher.display_name)  # Works
 print(minimal_publisher.cited_by_count)  # None (not selected)
+```
+
+## Publisher hierarchy and alternate titles
+
+```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]  # Elsevier BV
+print(f"Primary name: {publisher.display_name}")
+
+if publisher.parent_publisher:
+    parent = Publishers()[publisher.parent_publisher]
+    print(f"Parent: {parent.display_name}")
+
+if publisher.alternate_titles:
+    print("Also known as:")
+    for alt in publisher.alternate_titles[:5]:
+        print(f"  - {alt}")
 ```

--- a/docs/publishers/get-lists-of-publishers.md
+++ b/docs/publishers/get-lists-of-publishers.md
@@ -27,7 +27,10 @@ The response contains:
 
 ```python
 # Each result shows publisher information
-for publisher in first_page.results[:5]:  # First 5 publishers
+from openalex import Publishers
+
+first_page = Publishers().get()
+for publisher in first_page.results[:5]:
     print(f"\n{publisher.display_name}")
     print(f"  ID: {publisher.id}")
     print(f"  Works: {publisher.works_count:,}")
@@ -43,6 +46,8 @@ You can control pagination and sorting:
 
 ```python
 # Get a specific page with custom page size
+from openalex import Publishers
+
 page2 = Publishers().get(per_page=50, page=2)
 # This returns publishers 51-100
 
@@ -69,6 +74,8 @@ print(f"Fetched all {len(all_publishers)} publishers")
 Get a random sample of publishers:
 
 ```python
+from openalex import Publishers
+
 # Get 10 random publishers
 random_sample = Publishers().sample(10).get()
 
@@ -90,9 +97,11 @@ Limit the fields returned to improve performance:
 
 ```python
 # Request only specific fields
+from openalex import Publishers
+
 minimal_publishers = Publishers().select([
-    "id", 
-    "display_name", 
+    "id",
+    "display_name",
     "alternate_titles"
 ]).get()
 
@@ -105,6 +114,8 @@ for publisher in minimal_publishers.results:
 ## Practical example: Publisher hierarchy
 
 ```python
+from openalex import Publishers
+
 # Get all top-level publishers
 parent_publishers = Publishers().filter(hierarchy_level=0).get()
 print(f"Found {parent_publishers.meta.count} parent publishers")

--- a/docs/publishers/group-publishers.md
+++ b/docs/publishers/group-publishers.md
@@ -23,6 +23,8 @@ for group in country_stats.group_by[:10]:  # Top 10 countries
 ## Understanding group_by results
 
 ```python
+from openalex import Publishers
+
 # The result structure is different from regular queries
 result = Publishers().group_by("hierarchy_level").get()
 
@@ -40,6 +42,8 @@ for group in result.group_by:
 ### Basic grouping
 
 ```python
+from openalex import Publishers
+
 # Group by hierarchy level
 hierarchy_dist = Publishers().group_by("hierarchy_level").get()
 # Shows how many parent vs. subsidiary publishers
@@ -56,6 +60,8 @@ by_lineage = Publishers().group_by("lineage").get()
 ### Summary statistics grouping
 
 ```python
+from openalex import Publishers
+
 # Distribution of h-index values
 h_index_dist = Publishers().group_by("summary_stats.h_index").get()
 # See how research impact is distributed
@@ -72,6 +78,8 @@ impact_dist = Publishers().group_by("summary_stats.2yr_mean_citedness").get()
 Group_by becomes more insightful when combined with filters:
 
 ```python
+from openalex import Publishers
+
 # Country distribution for large publishers only
 large_pub_countries = (
     Publishers()
@@ -105,6 +113,8 @@ parent_by_continent = (
 While the API supports grouping by two dimensions, it's less common for publishers:
 
 ```python
+from openalex import Publishers
+
 # Publishers by country and hierarchy level
 country_hierarchy = Publishers().group_by(
     "country_codes",
@@ -122,6 +132,8 @@ for group in country_hierarchy.group_by[:20]:
 ### Example 1: Analyze publisher market concentration
 
 ```python
+from openalex import Publishers
+
 # Get top countries by publisher count
 def analyze_market_concentration():
     # Total publishers by country
@@ -169,6 +181,8 @@ analyze_market_concentration()
 ### Example 2: Publisher hierarchy analysis
 
 ```python
+from openalex import Publishers
+
 # Analyze publisher organizational structures
 def analyze_hierarchies():
     # Overall hierarchy distribution
@@ -198,6 +212,8 @@ analyze_hierarchies()
 ### Example 3: Impact analysis
 
 ```python
+from openalex import Publishers
+
 # Analyze research impact distribution
 def analyze_impact():
     # Group by h-index ranges
@@ -234,6 +250,8 @@ analyze_impact()
 Control how results are ordered:
 
 ```python
+from openalex import Publishers
+
 # Default: sorted by count (descending)
 default_sort = Publishers().group_by("country_codes").get()
 # US first (most publishers), then GB, DE, etc.

--- a/docs/publishers/publisher-object.md
+++ b/docs/publishers/publisher-object.md
@@ -16,6 +16,11 @@ print(type(publisher))  # <class 'openalex.models.publisher.Publisher'>
 
 ```python
 # Identifiers
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
+# Identifiers
 print(publisher.id)  # "https://openalex.org/P4310320990"
 print(publisher.display_name)  # "Elsevier BV"
 
@@ -44,6 +49,10 @@ print(publisher.updated_date)  # "2024-12-25T14:04:30.578837"
 Publishers can have parent-child relationships:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # Hierarchy level (0 = top parent, 1 = child, 2 = grandchild, etc.)
 print(f"Hierarchy level: {publisher.hierarchy_level}")
 
@@ -70,6 +79,10 @@ for i, ancestor_id in enumerate(publisher.lineage):
 Citation and productivity metrics:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 stats = publisher.summary_stats
 if stats:
     print(f"H-index: {stats.h_index}")  # e.g., 985
@@ -86,6 +99,10 @@ if stats:
 Track publication trends over the last 10 years:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 print("Publication trends:")
 for count in publisher.counts_by_year:
     print(f"  {count.year}: {count.works_count:,} works, "
@@ -105,6 +122,10 @@ if len(publisher.counts_by_year) >= 2:
 Access all known IDs:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 ids = publisher.ids
 print(f"OpenAlex: {ids.openalex}")
 if ids.ror:
@@ -125,6 +146,10 @@ print(f"Available IDs: {', '.join(available_ids)}")
 Publisher logos and seals:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # Full-size image (usually from Wikimedia)
 if publisher.image_url:
     print(f"Logo URL: {publisher.image_url}")
@@ -141,6 +166,10 @@ if publisher.image_thumbnail_url:
 Publishers can have multiple roles in the academic ecosystem:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # A publisher might also be a funder or institution
 print(f"This organization has {len(publisher.roles)} roles:")
 
@@ -160,11 +189,14 @@ for role in publisher.roles:
 Get all journals/sources from this publisher:
 
 ```python
+from openalex import Publishers, Sources
+
+publisher = Publishers()["P4310320990"]
+
 # This is the API URL to get all sources
 print(f"Sources URL: {publisher.sources_api_url}")
 
 # To actually fetch the sources using the client:
-from openalex import Sources
 
 # Get all sources published by this publisher
 publisher_sources = Sources().filter(
@@ -185,6 +217,10 @@ for source in publisher_sources.results[:5]:
 ### Get all subsidiaries
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # Find all children of this publisher
 children = Publishers().filter(parent_publisher=publisher.id).get()
 
@@ -200,6 +236,9 @@ print(f"Entire family: {family.meta.count} publishers")
 ### Navigate up the hierarchy
 
 ```python
+from openalex import Publishers
+
+# Helper to walk up the hierarchy
 def get_publisher_chain(publisher_id):
     """Get the full chain from publisher to top parent."""
     chain = []
@@ -213,6 +252,9 @@ def get_publisher_chain(publisher_id):
     return chain
 
 # Example usage
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
 chain = get_publisher_chain(publisher.id)
 print("Publisher hierarchy (child to parent):")
 for i, pub in enumerate(chain):
@@ -224,7 +266,9 @@ for i, pub in enumerate(chain):
 
 ```python
 # Get a sample of recent works from this publisher
-from openalex import Works
+from openalex import Publishers, Works
+
+publisher = Publishers()["P4310320990"]
 
 recent_works = (
     Works()
@@ -252,6 +296,10 @@ print(f"\nOpen Access rate: {oa_percentage:.1f}%")
 ## Geographic analysis
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # For publishers with multiple country codes
 if len(publisher.country_codes) > 1:
     print(f"International publisher with presence in:")
@@ -271,6 +319,10 @@ print(f"\nOther publishers in {publisher.country_codes[0]}: "
 Many fields can be None or empty:
 
 ```python
+from openalex import Publishers
+
+publisher = Publishers()["P4310320990"]
+
 # Safe access patterns
 if publisher.parent_publisher:
     print(f"Has parent: {publisher.parent_publisher}")

--- a/docs/publishers/search-publishers.md
+++ b/docs/publishers/search-publishers.md
@@ -24,6 +24,8 @@ The search checks both primary and alternate names:
 
 ```python
 # This searches both display_name and alternate_titles
+from openalex import Publishers
+
 elsevier_results = Publishers().search("elsevier").get()
 
 # Example matches might include:
@@ -40,6 +42,8 @@ Read more about search relevance, stemming, and boolean searches in the [search 
 You can also use search as a filter:
 
 ```python
+from openalex import Publishers
+
 # Search only in display_name (not alternate_titles)
 display_only = Publishers().filter(
     display_name={"search": "elsevier"}
@@ -68,6 +72,8 @@ Available search fields:
 Create a fast type-ahead search experience:
 
 ```python
+from openalex import Publishers
+
 # Get autocomplete suggestions
 suggestions = Publishers().autocomplete("els")
 
@@ -98,6 +104,8 @@ Else Kr\u00f6ner-Fresenius Foundation
 Search is most powerful when combined with filters:
 
 ```python
+from openalex import Publishers
+
 # Search for US university presses
 us_uni_presses = (
     Publishers()
@@ -138,6 +146,8 @@ medical_publishers = (
 
 ```python
 # When searching for a publisher group, check hierarchy
+from openalex import Publishers
+
 def find_publisher_family(search_term):
     # First, find potential matches
     matches = Publishers().search(search_term).get(per_page=20)
@@ -170,6 +180,8 @@ for parent_id, members in nature_families.items():
 
 ```python
 # Search for publishers in specific regions
+from openalex import Publishers
+
 def find_regional_publishers(search_term, country_codes):
     return (
         Publishers()
@@ -198,6 +210,8 @@ eu_oa_publishers = find_regional_publishers(
 
 ```python
 # Many publishers have similar names
+from openalex import Publishers
+
 cambridge_search = Publishers().search("Cambridge").get()
 
 # Distinguish between them using additional filters
@@ -221,6 +235,8 @@ major_cambridge = (
 
 ```python
 # Find all Springer-related entities
+from openalex import Publishers
+
 springer_all = Publishers().search("Springer").get(per_page=50)
 
 # Separate parents from children
@@ -249,6 +265,8 @@ for pub in springer_all.results:
 
 ```python
 # Example: Find the "real" publisher among many matches
+from openalex import Publishers
+
 def find_main_publisher(search_term):
     results = Publishers().search(search_term).get(per_page=10)
     


### PR DESCRIPTION
## Summary
- ensure each publisher doc code block imports Publishers
- re-fetch publisher objects in every example
- add parent and alternate title examples
- make publisher code snippets self-contained for testing

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684d6c127dcc832ba9fbe4ccfc834304