### PR TITLE
Enable docs tests from repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   captures ``retry-after`` values without triggering long retries in tests
 - Updated Ruff configuration to ignore test-only warnings
 - Pytest configuration skips docs-based examples
+- Docs tests can now be run from the repository root with `pytest --docs`
 - Refactored test suite for maintainability and clarity
 
 - Fixed utility helpers and improved parameter, retry, and text functions to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ markers = [
 ]
 
 addopts = [
+    "-p",
+    "tests.docs.plugin",
     "-m",
     "not docs",
     "--strict-markers",

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -6,22 +6,6 @@ from unittest.mock import Mock, AsyncMock
 import json
 
 
-def pytest_addoption(parser):
-    """Add custom command line options."""
-    parser.addoption(
-        "--docs",
-        action="store_true",
-        default=False,
-        help="Run documentation tests",
-    )
-    parser.addoption(
-        "--no-mock-api",
-        action="store_true",
-        default=False,
-        help="Run documentation tests with real API calls",
-    )
-
-
 def pytest_configure(config):
     """Configure pytest with custom markers."""
     config.addinivalue_line("markers", "docs: mark test as documentation test")

--- a/tests/docs/plugin.py
+++ b/tests/docs/plugin.py
@@ -1,0 +1,20 @@
+"""Pytest plugin for documentation test options."""
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register command line options for documentation tests."""
+    parser.addoption(
+        "--docs",
+        action="store_true",
+        default=False,
+        help="Run documentation tests",
+    )
+    parser.addoption(
+        "--no-mock-api",
+        action="store_true",
+        default=False,
+        help="Run documentation tests with real API calls",
+    )
+


### PR DESCRIPTION
## Summary
- load docs plugin via pytest `-p` option
- move docs CLI options to `tests/docs/plugin.py`
- update changelog with docs flag improvement

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684e75761d8c832b8d910dd07458f1fc