### PR TITLE
Fix documentation examples and autocomplete endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parameter serialization encodes spaces correctly and preserves comparison operators
 - Cache managers are isolated per configuration instance
 - Retry decorator now uses ``max_retries`` plus the initial attempt
+- Autocomplete requests now use ``/autocomplete/{endpoint}`` to avoid 404 errors
 - Pagination utilities no longer loop indefinitely when cursors are ignored and
   now respect ``max_results`` across sync and async iterators.
 

--- a/docs/authors/filter-authors.md
+++ b/docs/authors/filter-authors.md
@@ -34,7 +34,7 @@ page2 = query_orcid.get(page=2, per_page=100)  # Authors 101-200
 # Or iterate through all results (use with extreme caution!)
 for author in query_orcid.paginate(per_page=200):
     # This could make thousands of API calls!
-    process(author)
+    print(author.id)
 ```
 
 ## Authors attribute filters
@@ -217,7 +217,7 @@ non_us_authors = Authors().filter_not(
 ).get()
 
 # Authors without ORCID
-no_orcid = Authors().filter_not(has_orcid=True).get()
+no_orcid = Authors().filter(has_orcid=False).get()
 ```
 
 ### Range queries

--- a/docs/authors/get-a-single-author.md
+++ b/docs/authors/get-a-single-author.md
@@ -59,10 +59,7 @@ author = Authors()["https://orcid.org/0000-0002-1298-3089"]
 author = Authors()["orcid:0000-0002-1298-3089"]  # Shorter URN format
 
 # Get author by Scopus ID
-author = Authors()["scopus:7004185353"]
-
-# Get author by Twitter handle  
-author = Authors()["twitter:jasonpriem"]
+author = Authors()["scopus:36455008000"]
 
 # Get author by Wikipedia page
 author = Authors()["wikipedia:https://en.wikipedia.org/wiki/Heather_Piwowar"]
@@ -86,7 +83,9 @@ You can use `select` to limit the fields that are returned in an author object:
 from openalex import Authors
 
 # Fetch only specific fields to reduce response size
-minimal_author = Authors().select(["id", "display_name", "orcid"]).get("A5023888391")
+minimal_author = Authors().get(
+    "A5023888391", select=["id", "display_name", "orcid"]
+)
 
 # Now only the selected fields are populated
 print(minimal_author.display_name)  # Works

--- a/docs/authors/group-authors.md
+++ b/docs/authors/group-authors.md
@@ -6,7 +6,9 @@ You can group authors to get aggregated statistics without fetching individual a
 from openalex import Authors
 
 # Create a query that groups authors by their last known institution's continent
-continent_stats_query = Authors().group_by("last_known_institution.continent")
+continent_stats_query = Authors().group_by(
+    "last_known_institutions.continent"
+)
 
 # Execute the query to get COUNTS, not individual authors
 continent_stats = continent_stats_query.get()

--- a/docs/authors/limitations.md
+++ b/docs/authors/limitations.md
@@ -21,6 +21,9 @@ for work in many_author_works.results:
 To see the full list of authors, get the individual work record, which is never truncated:
 
 ```python
+# Include imports for standalone example
+from openalex import Works
+
 # Get complete work with all 249 authors
 full_work = Works()["W2168909179"]
 print(f"Total authors: {len(full_work.authorships)}")  # All 249 available
@@ -33,6 +36,9 @@ for i, authorship in enumerate(full_work.authorships, 1):
 This affects filtering as well. So if you filter works using an author ID or ROR, you will not receive works where that author is listed further than 100 places down on the list of authors. We plan to change this in the future, so that filtering works as expected.
 
 ```python
+# Include imports
+from openalex import Works
+
 # This might miss works where the author is listed after position 100
 author_works = Works().filter(
     authorships={"author": {"id": "A5023888391"}}

--- a/openalex/api.py
+++ b/openalex/api.py
@@ -307,7 +307,7 @@ class AsyncBaseAPI(Generic[T]):
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         connection = await self._get_connection()
-        url = self._build_url(f"{self.endpoint}/{AUTOCOMPLETE_PATH}")
+        url = self._build_url(f"{AUTOCOMPLETE_PATH}/{self.endpoint}")
         params_norm = normalize_params(params or {})
         params_norm[PARAM_Q] = query
         response = await connection.request(

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -263,7 +263,7 @@ class BaseEntity(Generic[T, F]):
         self, query: str, **params: Any
     ) -> ListResult[AutocompleteResult]:
         """Return autocomplete suggestions for this entity."""
-        url = self._build_url(f"{AUTOCOMPLETE_PATH}")
+        url = f"{self._connection.base_url}/{AUTOCOMPLETE_PATH}/{self.endpoint}"
         params_norm = normalize_params(params)
         params_norm[PARAM_Q] = query
         response = self._connection.request(

--- a/openalex/query.py
+++ b/openalex/query.py
@@ -164,8 +164,14 @@ class Query(Generic[T, F]):
     def _apply_logical_operation(
         self, filter_dict: dict[str, Any], operation: type[_LogicalExpression]
     ) -> dict[str, Any]:
-        """Apply a logical operation to all values in a filter dict."""
-        return {k: operation(v) for k, v in filter_dict.items()}
+        """Apply a logical operation recursively to all filter values."""
+
+        def apply(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {k: apply(v) for k, v in value.items()}
+            return operation(value)
+
+        return {k: apply(v) for k, v in filter_dict.items()}
 
     # --- builder methods -------------------------------------------------
     def filter(self, **kwargs: Any) -> Query[T, F]:

--- a/tests/behavior/test_async.py
+++ b/tests/behavior/test_async.py
@@ -226,7 +226,7 @@ class TestAsyncBehavior:
             results = await publishers.autocomplete("springer")
 
             _, kwargs = mock_request.call_args
-            assert kwargs["url"].endswith("/publishers/autocomplete")
+            assert kwargs["url"].endswith("/autocomplete/publishers")
             assert kwargs["params"]["q"] == "springer"
 
     async def test_async_first_helper(self):

--- a/tests/behavior/test_entities.py
+++ b/tests/behavior/test_entities.py
@@ -173,7 +173,7 @@ class TestEntityBehavior:
             results = Funders().autocomplete("National Institutes")
 
             _, kwargs = mock_request.call_args
-            assert kwargs["url"].endswith("/funders/autocomplete")
+            assert kwargs["url"].endswith("/autocomplete/funders")
             assert kwargs["params"]["q"] == "National Institutes"
 
             assert len(results.results) == 1

--- a/tests/behavior/test_query.py
+++ b/tests/behavior/test_query.py
@@ -259,7 +259,7 @@ class TestQueryBehavior:
             results = Institutions().autocomplete("massachus")
 
             _, kwargs = mock_request.call_args
-            assert kwargs["url"].endswith("/institutions/autocomplete")
+            assert kwargs["url"].endswith("/autocomplete/institutions")
             assert kwargs["params"]["q"] == "massachus"
             assert len(results.results) == 1
 


### PR DESCRIPTION
## Summary
- fix recursive filter operators
- correct autocomplete endpoint
- update docs examples for authors

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/docs/test_authors.py --docs` *(fails: HTTP 403 errors from API)*

------
https://chatgpt.com/codex/tasks/task_e_684eb332ec04832b8a2b5baa2590ac3b