### PR TITLE
Update docs for Pydantic model_dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Request caching disabled by default
 - Verified caching behavior with updated tests
 - Documentation examples for institutions are now self-contained
+- Updated docs to use `model_dump()` instead of `dict()`
 
 ### Fixed
 - Retry logic now honors `max_retries` without exceeding the limit

--- a/docs/authors/author-object.md
+++ b/docs/authors/author-object.md
@@ -155,7 +155,7 @@ if ids.wikipedia:
 
 # Check what IDs are available
 available_ids = [
-    id_type for id_type, value in ids.dict().items() 
+    id_type for id_type, value in ids.model_dump().items()
     if value is not None
 ]
 print(f"Available IDs: {', '.join(available_ids)}")

--- a/docs/publishers/publisher-object.md
+++ b/docs/publishers/publisher-object.md
@@ -135,7 +135,7 @@ if ids.wikidata:
 
 # Check what IDs are available
 available_ids = [
-    id_type for id_type, value in ids.dict().items() 
+    id_type for id_type, value in ids.model_dump().items()
     if value is not None
 ]
 print(f"Available IDs: {', '.join(available_ids)}")


### PR DESCRIPTION
## Summary
- use `model_dump()` in author and publisher docs
- note deprecation fix in changelog

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/docs/test_authors.py --docs`

------
https://chatgpt.com/codex/tasks/task_e_684ed7e7362c832b9f47d9ef7b994f2a