### PR TITLE
Fix docs examples for concept filters

### DIFF
--- a/docs/concepts/concept-object.md
+++ b/docs/concepts/concept-object.md
@@ -76,7 +76,7 @@ stats = concept.summary_stats
 if stats:
     print(f"H-index: {stats.h_index}")
     print(f"i10-index: {stats.i10_index:,}")
-    print(f"2-year mean citedness: {stats['2yr_mean_citedness']:.2f}")
+    print(f"2-year mean citedness: {stats.two_year_mean_citedness:.2f}")
     
     # These help assess concept impact
     if stats.h_index > 200:
@@ -255,7 +255,7 @@ def analyze_concept_impact(concept_id):
         print(f"\nImpact Metrics:")
         print(f"  H-index: {stats.h_index}")
         print(f"  i10-index: {stats.i10_index:,}")
-        print(f"  Mean citedness: {stats['2yr_mean_citedness']:.2f}")
+        print(f"  Mean citedness: {stats.two_year_mean_citedness:.2f}")
         
         # Calculate average citations per work
         if concept.works_count > 0:

--- a/docs/concepts/filter-concepts.md
+++ b/docs/concepts/filter-concepts.md
@@ -189,8 +189,8 @@ non_cs = Concepts().filter_not(ancestors={"id": "C41008148"}).get()
 non_root = Concepts().filter_not(level=0).get()
 
 # Concepts with limited impact
-low_impact = Concepts().filter_not(
-    summary_stats={"h_index": {"gte": 50}}
+low_impact = Concepts().filter_lt(
+    summary_stats={"h_index": 50}
 ).get()
 ```
 
@@ -202,8 +202,7 @@ from openalex import Concepts
 # Mid-level concepts (levels 2-4)
 mid_levels = (
     Concepts()
-    .filter_gte(level=2)
-    .filter_lte(level=4)
+    .filter(level={"gte": 2, "lte": 4})
     .get()
 )
 

--- a/docs/concepts/get-lists-of-concepts.md
+++ b/docs/concepts/get-lists-of-concepts.md
@@ -67,12 +67,17 @@ most_cited = Concepts().sort(cited_by_count="desc").get()
 root_concepts = Concepts().filter(level=0).sort(display_name="asc").get()
 print(f"Found {root_concepts.meta.count} root concepts")  # Should be 19
 
-# Get ALL concepts (feasible with ~65,000)
-# This will make about 325 API calls at 200 per page
+# Get many concepts (feasible with ~65,000)
+# This example stops after about 1,000 concepts to avoid huge downloads
 all_concepts = []
-for concept in Concepts().paginate(per_page=200):
-    all_concepts.append(concept)
-print(f"Fetched all {len(all_concepts)} concepts")
+page_count = 0
+for page in Concepts().paginate(per_page=200):
+    page_count += 1
+    if page_count > 5:  # Roughly 1,000 concepts
+        break
+    all_concepts.extend(page.results)
+
+print(f"Fetched {len(all_concepts)} concepts")
 ```
 
 ## Sample concepts

--- a/docs/concepts/group-concepts.md
+++ b/docs/concepts/group-concepts.md
@@ -133,7 +133,12 @@ You can group by two dimensions:
 from openalex import Concepts
 # ⚠️ DEPRECATED: Consider using Topics instead
 # Level and ancestor combination
-level_ancestor = Concepts().group_by("level,ancestors.id").get()
+level_ancestor = (
+    Concepts()
+    .group_by("level")
+    .group_by("ancestors.id")
+    .get()
+)
 
 # This shows distribution of concepts by level within each ancestor branch
 for group in level_ancestor.group_by[:20]:
@@ -246,11 +251,11 @@ def analyze_concept_impact():
     
     for range_name, min_h, max_h in h_index_ranges:
         # Build query
-        query = Concepts()
-        if min_h > 0:
-            query = query.filter_gte(summary_stats={"h_index": min_h})
+        filters = {"gte": min_h}
         if max_h < float('inf'):
-            query = query.filter_lt(summary_stats={"h_index": max_h})
+            filters["lte"] = max_h
+
+        query = Concepts().filter(summary_stats={"h_index": filters})
         
         # Get results
         result = query.get()


### PR DESCRIPTION
## Summary
- use valid range filters for concepts examples
- fix sample stats attribute usage
- show limited pagination when listing many concepts
- chain group_by calls correctly

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee59bd358832b8bb8f2bc811612ec