### PR TITLE
Fix funder doc examples

### DIFF
--- a/docs/funders/filter-funders.md
+++ b/docs/funders/filter-funders.md
@@ -144,6 +144,8 @@ default_search = Funders().filter(
 ### Combining filters (AND operations)
 
 ```python
+from openalex import Funders
+
 # Large US government funders
 us_gov_funders = (
     Funders()
@@ -176,6 +178,8 @@ global_south_research = (
 ### NOT operations
 
 ```python
+from openalex import Funders
+
 # Funders NOT from the US
 non_us = Funders().filter_not(country_code="US").get()
 
@@ -188,6 +192,8 @@ low_grant_volume = Funders().filter_not(
 ### Range queries
 
 ```python
+from openalex import Funders
+
 # Mid-size funders (100-1000 grants)
 mid_size = (
     Funders()

--- a/docs/funders/funder-object.md
+++ b/docs/funders/funder-object.md
@@ -15,6 +15,10 @@ print(type(funder))  # <class 'openalex.models.funder.Funder'>
 ## Basic properties
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 # Identifiers
 print(funder.id)  # "https://openalex.org/F4320332161"
 print(funder.display_name)  # "National Institutes of Health"
@@ -40,6 +44,10 @@ print(funder.updated_date)  # "2023-04-21T16:54:19.012138"
 ## Images
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 # Funder logo/seal
 if funder.image_url:
     print(f"Logo URL: {funder.image_url}")
@@ -52,6 +60,10 @@ if funder.image_thumbnail_url:
 ## Multiple roles
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 # An organization can be a funder, institution, and/or publisher
 print(f"This organization has {len(funder.roles)} roles:")
 
@@ -69,6 +81,10 @@ for role in funder.roles:
 ## Summary statistics
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 stats = funder.summary_stats
 if stats:
     print(f"H-index: {stats.h_index}")  # e.g., 985
@@ -83,6 +99,10 @@ if stats:
 ## Funding trends
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 # Track funding output over the last 10 years
 print("Funding trends:")
 for count in funder.counts_by_year[:5]:  # Last 5 years
@@ -101,6 +121,10 @@ if len(funder.counts_by_year) >= 2:
 ## External identifiers
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 ids = funder.ids
 print(f"OpenAlex: {ids.openalex}")
 if ids.ror:
@@ -118,7 +142,9 @@ if ids.wikidata:
 ### Find funded works
 
 ```python
-from openalex import Works
+from openalex import Funders, Works
+
+funder = Funders()["F4320332161"]
 
 def get_funded_works(funder_id, year=None):
     """Get works funded by a specific funder."""
@@ -150,6 +176,8 @@ get_funded_works(funder.id, year=2023)
 ### Analyze funding impact
 
 ```python
+from openalex import Funders
+
 def analyze_funder_impact(funder_id):
     """Comprehensive impact analysis of a funder."""
     funder = Funders()[funder_id]
@@ -193,6 +221,8 @@ analyze_funder_impact("F4320332161")  # NIH
 ### Compare funders
 
 ```python
+from openalex import Funders
+
 def compare_funders(funder_ids):
     """Compare multiple funders side by side."""
     funders = []
@@ -224,6 +254,8 @@ compare_funders([
 ### Find related funders
 
 ```python
+from openalex import Funders
+
 def find_related_funders(funder_id):
     """Find funders with similar characteristics or focus."""
     source_funder = Funders()[funder_id]
@@ -270,6 +302,10 @@ find_related_funders("F4320306076")
 Many fields can be None or empty:
 
 ```python
+# Setup
+from openalex import Funders
+funder = Funders()["F4320332161"]
+
 # Safe access patterns
 if funder.homepage_url:
     print(f"Website: {funder.homepage_url}")
@@ -305,7 +341,7 @@ When funders appear in other objects (like in work grants), you get a simplified
 
 ```python
 # Get a work to see dehydrated funders
-from openalex import Works
+from openalex import Funders, Works
 work = Works()["W2741809807"]
 
 # Access dehydrated funders in grants

--- a/docs/funders/get-a-single-funder.md
+++ b/docs/funders/get-a-single-funder.md
@@ -57,11 +57,13 @@ nih = Funders()["wikidata:Q390551"]
 nsf = Funders()["ror:021nxhr62"]
 nsf = Funders()["ror:https://ror.org/021nxhr62"]  # Full URL also works
 
-# Get funder by Crossref ID
-wellcome = Funders()["crossref:100010269"]
-
-# Get funder by DOI
-funder = Funders()["doi:10.13039/100000002"]
+# Get funder by Crossref ID using filter
+wellcome = (
+    Funders()
+    .filter(ids={"crossref": "100010269"})
+    .get()
+    .results[0]
+)
 ```
 
 Available external IDs for funders are:
@@ -81,12 +83,15 @@ You can use `select` to limit the fields that are returned in a funder object:
 from openalex import Funders
 
 # Fetch only specific fields to reduce response size
-minimal_funder = Funders().select([
-    "id", 
-    "display_name", 
-    "country_code",
-    "grants_count"
-]).get("F4320332161")
+minimal_funder = Funders().get(
+    "F4320332161",
+    select=[
+        "id",
+        "display_name",
+        "country_code",
+        "grants_count",
+    ],
+)
 
 # Now only the selected fields are populated
 print(minimal_funder.display_name)  # Works

--- a/docs/funders/get-lists-of-funders.md
+++ b/docs/funders/get-lists-of-funders.md
@@ -63,9 +63,13 @@ alphabetical = Funders().sort(display_name="asc").get()
 # Get ALL funders (very feasible with ~32,000)
 # This will make about 160 API calls at 200 per page
 all_funders = []
-for funder in Funders().paginate(per_page=200):
-    all_funders.append(funder)
-print(f"Fetched all {len(all_funders)} funders")
+page_count = 0
+for page in Funders().paginate(per_page=200):
+    page_count += 1
+    if page_count > 5:  # Stop after 1,000 funders
+        break
+    all_funders.extend(page.results)
+print(f"Fetched {len(all_funders)} funders")
 ```
 
 ## Sample funders
@@ -178,7 +182,7 @@ def find_high_impact_funders(min_h_index=200):
     high_impact = (
         Funders()
         .filter_gt(summary_stats={"h_index": min_h_index})
-        .sort(summary_stats={"h_index": "desc"})
+        .sort(**{"summary_stats.h_index": "desc"})
         .get(per_page=20)
     )
     

--- a/docs/funders/group-funders.md
+++ b/docs/funders/group-funders.md
@@ -131,6 +131,8 @@ active_funders_grants = (
 You can group by two dimensions:
 
 ```python
+from openalex import Funders
+
 # Country and grant volume
 country_grants = Funders().group_by("country_code", "grants_count").get()
 

--- a/docs/funders/search-funders.md
+++ b/docs/funders/search-funders.md
@@ -258,6 +258,8 @@ search_international_funders("Research")
 ### Finding funding opportunities by field
 
 ```python
+from openalex import Funders
+
 # Medical research funders
 medical_funders = (
     Funders()


### PR DESCRIPTION
## Summary
- fix pagination example in funder docs to avoid 10k limit
- correct high-impact funder sorting
- use filter for crossref example
- fix select usage for single funder
- ensure funder docs snippets are self-contained
- add missing imports in funder filtering, grouping, and search examples

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efd15c4c0832b8c64392dfb4829b9