### PR TITLE
Fix documentation examples for institutions

### DIFF
--- a/docs/institutions/get-a-single-institution.md
+++ b/docs/institutions/get-a-single-institution.md
@@ -22,7 +22,7 @@ institution = Institutions()["I27837315"]  # University of Michigan–Ann Arbor
 print(f"OpenAlex ID: {institution.id}")
 print(f"ROR: {institution.ror}")
 print(f"GRID: {institution.ids.grid}")
-print(f"Wikidata: {institution.wikidata}")
+print(f"Wikidata: {institution.ids.wikidata}")
 print(f"Name: {institution.display_name}")
 print(f"Country: {institution.country_code}")
 print(f"Type: {institution.type}")

--- a/docs/institutions/get-lists-of-institutions.md
+++ b/docs/institutions/get-lists-of-institutions.md
@@ -64,7 +64,7 @@ alphabetical = Institutions().sort(display_name="asc").get()
 # Get ALL institutions (feasible with ~109,000)
 # Limit to the first 1,000 to avoid huge downloads
 all_institutions = []
-for institution in Institutions().paginate(per_page=200):
+for institution in Institutions().paginate(per_page=200, cursor="*"):
     all_institutions.append(institution)
     if len(all_institutions) >= 1000:  # Stop after 1,000
         break


### PR DESCRIPTION
## Summary
- use cursor pagination when iterating over all institutions
- correct SummaryStats access
- make concept example self-contained
- import Institutions for child helper
- handle dict-based authorships in collaboration example
- update Ivy League institution IDs
- fix Wikidata property example

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/docs/test_institutions.py --docs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f14148ef4832bb66f02a537f2af2d