### PR TITLE
Fix publisher docs examples

### DIFF
--- a/docs/publishers/get-a-single-publisher.md
+++ b/docs/publishers/get-a-single-publisher.md
@@ -48,16 +48,13 @@ for pub in multiple_publishers.results:
 You can look up publishers using external IDs such as a Wikidata ID:
 
 ```python
-# Get publisher by Wikidata ID
+# Get publisher by ROR ID
 from openalex import Publishers
 
-publisher = Publishers()["wikidata:Q1479654"]
+publisher = Publishers()["ror:https://ror.org/0117jxy09"]
 
-# Get publisher by ROR ID
-publisher = Publishers()["ror:https://ror.org/02scfj030"]
-
-# Direct lookup by full URL also works
-publisher = Publishers()["https://www.wikidata.org/entity/Q746413"]
+# Direct lookup by full URL also works with ROR
+publisher = Publishers()["https://ror.org/0117jxy09"]
 ```
 
 Available external IDs for publishers are:
@@ -75,7 +72,7 @@ You can use `select` to limit the fields that are returned in a publisher object
 # Fetch only specific fields to reduce response size
 from openalex import Publishers
 
-minimal_publisher = Publishers().select(["id", "display_name", "works_count"]).get("P4310319965")
+minimal_publisher = Publishers().select(["id", "display_name", "works_count"]).get(id="P4310319965")
 
 # Now only the selected fields are populated
 print(minimal_publisher.display_name)  # Works

--- a/docs/publishers/get-lists-of-publishers.md
+++ b/docs/publishers/get-lists-of-publishers.md
@@ -64,9 +64,11 @@ alphabetical = Publishers().sort(display_name="asc").get()
 # Get ALL publishers (feasible with only ~10,000)
 # This will make about 50 API calls
 all_publishers = []
-for publisher in Publishers().paginate(per_page=200):
-    all_publishers.append(publisher)
-print(f"Fetched all {len(all_publishers)} publishers")
+for i, page in enumerate(Publishers().paginate(per_page=200)):
+    if i >= 5:  # Stop after ~1000 results
+        break
+    all_publishers.extend(page.results)
+print(f"Fetched {len(all_publishers)} publishers")
 ```
 
 ## Sample publishers

--- a/docs/publishers/group-publishers.md
+++ b/docs/publishers/group-publishers.md
@@ -116,10 +116,12 @@ While the API supports grouping by two dimensions, it's less common for publishe
 from openalex import Publishers
 
 # Publishers by country and hierarchy level
-country_hierarchy = Publishers().group_by(
-    "country_codes",
-    "hierarchy_level"
-).get()
+country_hierarchy = (
+    Publishers()
+    .group_by("country_codes")
+    .group_by("hierarchy_level")
+    .get()
+)
 
 # This shows which countries have more complex publisher structures
 for group in country_hierarchy.group_by[:20]:

--- a/docs/publishers/publisher-object.md
+++ b/docs/publishers/publisher-object.md
@@ -87,7 +87,9 @@ stats = publisher.summary_stats
 if stats:
     print(f"H-index: {stats.h_index}")  # e.g., 985
     print(f"i10-index: {stats.i10_index:,}")  # e.g., 176,682
-    print(f"2-year mean citedness: {stats['2yr_mean_citedness']:.2f}")
+    print(
+        f"2-year mean citedness: {stats.two_year_mean_citedness:.2f}"
+    )
     
     # These metrics help assess publisher impact
     if stats.h_index > 500:
@@ -288,7 +290,7 @@ for work_type, count in sorted(work_types.items(), key=lambda x: x[1], reverse=T
     print(f"  {work_type}: {count}")
 
 # Analyze open access
-oa_count = sum(1 for w in recent_works.results if w.open_access.is_oa)
+oa_count = sum(1 for w in recent_works.results if w.is_oa)
 oa_percentage = (oa_count / len(recent_works.results)) * 100
 print(f"\nOpen Access rate: {oa_percentage:.1f}%")
 ```

--- a/docs/publishers/search-publishers.md
+++ b/docs/publishers/search-publishers.md
@@ -172,7 +172,7 @@ nature_families = find_publisher_family("Nature")
 for parent_id, members in nature_families.items():
     print(f"\nFamily {parent_id}:")
     for pub in members:
-        indent = "  " * pub.hierarchy_level
+        indent = "  " * (pub.hierarchy_level or 0)
         print(f"{indent}{pub.display_name}")
 ```
 
@@ -240,8 +240,8 @@ from openalex import Publishers
 springer_all = Publishers().search("Springer").get(per_page=50)
 
 # Separate parents from children
-parents = [p for p in springer_all.results if p.hierarchy_level == 0]
-imprints = [p for p in springer_all.results if p.hierarchy_level > 0]
+parents = [p for p in springer_all.results if (p.hierarchy_level or 0) == 0]
+imprints = [p for p in springer_all.results if (p.hierarchy_level or 0) > 0]
 
 print(f"Found {len(parents)} parent companies")
 print(f"Found {len(imprints)} imprints/subsidiaries")


### PR DESCRIPTION
## Summary
- correct `SummaryStats` usage
- update get-single-publisher examples
- fix multi-dimensional groupings
- handle missing hierarchy values in search
- cap pagination at ~1000 publishers

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f19972c14832b82886d45b8d658d0