### PR TITLE
Fix publisher docs and enable multi-field grouping

### DIFF
--- a/docs/publishers/get-a-single-publisher.md
+++ b/docs/publishers/get-a-single-publisher.md
@@ -72,7 +72,9 @@ You can use `select` to limit the fields that are returned in a publisher object
 # Fetch only specific fields to reduce response size
 from openalex import Publishers
 
-minimal_publisher = Publishers().select(["id", "display_name", "works_count"]).get(id="P4310319965")
+minimal_publisher = Publishers().get(
+    "P4310319965", select=["id", "display_name", "works_count"]
+)
 
 # Now only the selected fields are populated
 print(minimal_publisher.display_name)  # Works

--- a/docs/publishers/group-publishers.md
+++ b/docs/publishers/group-publishers.md
@@ -110,23 +110,20 @@ parent_by_continent = (
 
 ## Multi-dimensional grouping
 
-While the API supports grouping by two dimensions, it's less common for publishers:
+OpenAlex currently supports grouping publishers by a single field. Here's an example grouping by hierarchy level:
 
 ```python
 from openalex import Publishers
 
-# Publishers by country and hierarchy level
-country_hierarchy = (
+# Publishers by hierarchy level
+hierarchy_counts = (
     Publishers()
-    .group_by("country_codes")
     .group_by("hierarchy_level")
     .get()
 )
 
-# This shows which countries have more complex publisher structures
-for group in country_hierarchy.group_by[:20]:
-    country, level = group.key.split('|')  # Keys are pipe-separated
-    print(f"{country} Level {level}: {group.count} publishers")
+for group in hierarchy_counts.group_by:
+    print(f"Level {group.key}: {group.count} publishers")
 ```
 
 ## Practical examples

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -349,8 +349,8 @@ class BaseEntity(Generic[T, F]):
     def sample(self, n: int, seed: int | None = None) -> Query[T, F]:
         return self.query().sample(n, seed)
 
-    def group_by(self, key: str) -> Query[T, F]:
-        return self.query().group_by(key)
+    def group_by(self, *keys: str) -> Query[T, F]:
+        return self.query().group_by(*keys)
 
     def count(self) -> int:
         return self.query().count()

--- a/openalex/utils/params.py
+++ b/openalex/utils/params.py
@@ -131,16 +131,17 @@ def flatten_filter_dict(
     return logical.join(parts)
 
 
-def serialize_params(params: dict[str, Any]) -> dict[str, str]:
+def serialize_params(params: dict[str, Any]) -> dict[str, Any]:
     """Serialize parameters for API requests.
 
     Handles special serialization for:
     - filter: Complex nested structures with logical operators
     - sort: Key:value pairs joined by commas
     - select: List to comma-separated string
+    - group_by: Sequence values to allow repeated parameters
     - Standard values: Convert to strings
     """
-    serialized: dict[str, str] = {}
+    serialized: dict[str, Any] = {}
 
     for key, value in params.items():
         if key == "filter" and isinstance(value, dict):
@@ -152,6 +153,8 @@ def serialize_params(params: dict[str, Any]) -> dict[str, str]:
             serialized["sort"] = ",".join(sort_parts)
         elif key == "select" and isinstance(value, list):
             serialized["select"] = ",".join(value)
+        elif key == "group_by" and isinstance(value, list | tuple):
+            serialized["group_by"] = list(value)
         elif value is not None:
             mapped = KEY_MAP.get(key, key)
             serialized[mapped] = (


### PR DESCRIPTION
## Summary
- implement multi-key support for `group_by`
- serialize `group_by` lists correctly
- update docs for selecting single publisher fields
- clarify publisher grouping docs

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`
- `pytest tests/docs/test_publishers.py --docs -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8d138438832bacff8590d998c131