### PR TITLE
Fix source docs examples

### DIFF
--- a/docs/sources/filter-sources.md
+++ b/docs/sources/filter-sources.md
@@ -76,8 +76,8 @@ springer_nature_lineage = Sources().filter(
     host_organization_lineage="P4310319965"
 ).get()
 
-# Filter by exact publisher match
-exact_publisher = Sources().filter(publisher="Elsevier BV").get()
+# Filter by exact host organization (publisher) match
+exact_publisher = Sources().filter(host_organization="P4310320595").get()
 ```
 
 ### Open Access filters
@@ -121,9 +121,12 @@ from openalex import Sources
 
 # Filter by impact factor (2-year mean citedness)
 high_impact = Sources().filter_gt(summary_stats={"2yr_mean_citedness": 10.0}).get()
-medium_impact = Sources().filter_range(
-    summary_stats={"2yr_mean_citedness": [2.0, 5.0]}
-).get()
+medium_impact = (
+    Sources()
+    .filter_gt(summary_stats={"2yr_mean_citedness": 2.0})
+    .filter_lt(summary_stats={"2yr_mean_citedness": 5.0})
+    .get()
+)
 
 # Filter by h-index
 high_h_index = Sources().filter_gt(summary_stats={"h_index": 200}).get()
@@ -220,7 +223,7 @@ high_impact_oa = (
     .filter(type="journal")
     .filter(is_oa=True)
     .filter_gt(summary_stats={"2yr_mean_citedness": 5.0})
-    .sort(summary_stats={"2yr_mean_citedness": "desc"})
+    .sort(**{"summary_stats.2yr_mean_citedness": "desc"})
     .get()
 )
 
@@ -253,10 +256,8 @@ non_us = Sources().filter_not(country_code="US").get()
 # Non-journal sources
 non_journals = Sources().filter_not(type="journal").get()
 
-# Sources without APCs
-no_apc = Sources().filter_not(
-    apc_usd={"exists": True}
-).get()
+# Sources without APC information
+no_apc = Sources().filter(apc_usd=None).get()
 ```
 
 ### Range queries
@@ -297,7 +298,7 @@ def find_affordable_oa_journals(max_apc=1500, min_impact=2.0):
         .filter(is_oa=True)
         .filter_lt(apc_usd=max_apc)
         .filter_gt(summary_stats={"2yr_mean_citedness": min_impact})
-        .sort(summary_stats={"2yr_mean_citedness": "desc"})
+        .sort(**{"summary_stats.2yr_mean_citedness": "desc"})
         .get(per_page=20)
     )
     

--- a/docs/sources/get-a-single-source.md
+++ b/docs/sources/get-a-single-source.md
@@ -66,14 +66,8 @@ nature_comms = Sources()["issn:2041-1723"]
 source = Sources()["issn:1476-4687"]  # Print ISSN
 source = Sources()["issn:0028-0836"]  # Electronic ISSN
 
-# Get source by Wikidata ID
-source = Sources()["wikidata:Q180445"]
-
 # Get source by MAG ID
 source = Sources()["mag:137773608"]
-
-# Get source by Fatcat ID
-source = Sources()["fatcat:z3ijzhu7zzey3f7jwws7rzopoq"]
 ```
 
 Available external IDs for sources are:
@@ -93,12 +87,15 @@ You can use `select` to limit the fields that are returned in a source object:
 from openalex import Sources
 
 # Fetch only specific fields to reduce response size
-minimal_source = Sources().select([
-    "id", 
-    "display_name", 
-    "type",
-    "is_oa"
-]).get("S137773608")
+minimal_source = (
+    Sources()
+    .select([
+        "id",
+        "display_name",
+        "type",
+        "is_oa",
+    ])
+)["S137773608"]
 
 # Now only the selected fields are populated
 print(minimal_source.display_name)  # Works

--- a/docs/sources/get-lists-of-sources.md
+++ b/docs/sources/get-lists-of-sources.md
@@ -44,6 +44,8 @@ for source in first_page.results[:5]:  # First 5 sources
 You can control pagination and sorting:
 
 ```python
+from openalex import Sources
+
 # Get a specific page with custom page size
 page2 = Sources().get(per_page=50, page=2)
 # This returns sources 51-100
@@ -56,7 +58,7 @@ most_cited = Sources().sort(cited_by_count="desc").get()
 most_productive = Sources().sort(works_count="desc").get()
 
 # Sort by impact factor (2-year mean citedness)
-high_impact = Sources().sort(summary_stats={"2yr_mean_citedness": "desc"}).get()
+high_impact = Sources().sort(**{"summary_stats.2yr_mean_citedness": "desc"}).get()
 
 # Alphabetical by name
 alphabetical = Sources().sort(display_name="asc").get()
@@ -64,9 +66,9 @@ alphabetical = Sources().sort(display_name="asc").get()
 # Get ALL sources (feasible with ~249,000)
 # This will make about 1,250 API calls at 200 per page
 all_sources = []
-for source in Sources().paginate(per_page=200):
+for source in Sources().paginate(per_page=200, max_results=12000):
     all_sources.append(source)
-print(f"Fetched all {len(all_sources)} sources")
+print(f"Fetched {len(all_sources)} sources")
 ```
 
 ## Sample sources

--- a/docs/sources/group-sources.md
+++ b/docs/sources/group-sources.md
@@ -5,8 +5,8 @@ You can group sources to get aggregated statistics without fetching individual s
 ```python
 from openalex import Sources
 
-# Create a query that groups sources by publisher
-publisher_stats_query = Sources().group_by("publisher")
+# Create a query that groups sources by host organization
+publisher_stats_query = Sources().group_by("host_organization")
 
 # Execute the query to get COUNTS, not individual sources
 publisher_stats = publisher_stats_query.get()
@@ -182,11 +182,11 @@ country_type = Sources().group_by("country_code", "type").get()
 for group in country_type.group_by[:20]:
     # Keys are pipe-separated for multi-dimensional groups
     country, source_type = group.key.split('|')
-    oa_status = "OA" if source_type == "True" else "Subscription"
     print(f"{country} - {source_type}: {group.count}")
 
 # Publisher and source type
-publisher_types = Sources().group_by("publisher", "type").get()
+# Group by host organization and source type
+publisher_types = Sources().group_by("host_organization", "type").get()
 # See what types of sources each publisher has
 ```
 
@@ -224,7 +224,7 @@ def analyze_oa_landscape():
         Sources()
         .filter(is_oa=True)
         .filter(type="journal")
-        .filter(apc_usd={"exists": True})
+        .filter_gt(apc_usd=0)
         .group_by("apc_prices.currency")
         .get()
     )
@@ -262,13 +262,13 @@ def analyze_publisher_concentration():
     """Analyze market concentration in academic publishing."""
     
     # Top publishers by number of sources
-    by_publisher = Sources().group_by("publisher").get()
+    by_publisher = Sources().group_by("host_organization").get()
     
     # Top publishers of OA sources
     oa_publishers = (
         Sources()
         .filter(is_oa=True)
-        .group_by("publisher")
+        .group_by("host_organization")
         .get()
     )
     
@@ -300,7 +300,7 @@ def analyze_publisher_concentration():
         regional_publishers = (
             Sources()
             .filter(country_code=countries)
-            .group_by("publisher")
+            .group_by("host_organization")
             .get()
         )
         
@@ -411,7 +411,7 @@ Control how results are ordered:
 from openalex import Sources
 
 # Default: sorted by count (descending)
-default_sort = Sources().group_by("publisher").get()
+default_sort = Sources().group_by("host_organization").get()
 # Elsevier first (most sources), then Springer, etc.
 
 # Sort by key instead of count
@@ -419,7 +419,7 @@ alphabetical = Sources().group_by("type").sort(key="asc").get()
 # conference, ebook platform, journal... (alphabetical)
 
 # Sort by count ascending (smallest groups first)
-smallest_first = Sources().group_by("publisher").sort(count="asc").get()
+smallest_first = Sources().group_by("host_organization").sort(count="asc").get()
 # Publishers with fewest sources first
 ```
 

--- a/docs/sources/search-sources.md
+++ b/docs/sources/search-sources.md
@@ -25,6 +25,7 @@ for source in results.results[:5]:
 The search checks multiple fields:
 
 ```python
+from openalex import Sources
 # This searches display_name, alternate_titles, AND abbreviated_title
 nature_results = Sources().search("Nature").get()
 
@@ -133,7 +134,7 @@ high_impact_search = (
     .search("Science")
     .filter(type="journal")
     .filter_gt(summary_stats={"2yr_mean_citedness": 5.0})
-    .sort(summary_stats={"2yr_mean_citedness": "desc"})
+    .sort(**{"summary_stats.2yr_mean_citedness": "desc"})
     .get()
 )
 
@@ -210,7 +211,7 @@ def find_sources_by_topic(topic, source_type=None):
         print(f"   Type: {source.type}")
         print(f"   Works: {source.works_count:,}")
         if source.summary_stats and source.type == "journal":
-            impact = source.summary_stats.get("2yr_mean_citedness", 0)
+            impact = source.summary_stats.two_year_mean_citedness or 0
             print(f"   Impact Factor: {impact:.2f}")
 
 # Examples
@@ -258,6 +259,7 @@ search_publisher_catalog("P4310319965", "quantum")
 ### Finding specific journal types
 
 ```python
+from openalex import Sources
 # Open access journals in a field
 oa_cs_journals = (
     Sources()
@@ -274,7 +276,7 @@ top_medical = (
     .search("medical OR medicine OR clinical")
     .filter(type="journal")
     .filter_gt(summary_stats={"2yr_mean_citedness": 10.0})
-    .sort(summary_stats={"2yr_mean_citedness": "desc"})
+    .sort(**{"summary_stats.2yr_mean_citedness": "desc"})
     .get()
 )
 
@@ -346,7 +348,7 @@ def comprehensive_journal_search(search_terms, min_impact=None):
         for source in results.results:
             # Apply additional filters
             if min_impact and source.summary_stats:
-                impact = source.summary_stats.get("2yr_mean_citedness", 0)
+                impact = source.summary_stats.two_year_mean_citedness or 0
                 if impact < min_impact:
                     continue
             

--- a/docs/sources/source-object.md
+++ b/docs/sources/source-object.md
@@ -15,6 +15,9 @@ print(type(source))  # <class 'openalex.models.source.Source'>
 ## Basic properties
 
 ```python
+from openalex import Sources
+source = Sources()["S137773608"]
+
 # Identifiers
 print(source.id)  # "https://openalex.org/S137773608"
 print(source.issn_l)  # "0028-0836" (canonical ISSN)
@@ -53,6 +56,9 @@ print(source.updated_date)  # "2024-01-02T00:27:23.088909"
 ## Article Processing Charges (APCs)
 
 ```python
+from openalex import Sources
+source = Sources()["S137773608"]
+
 # APC information from DOAJ
 if source.apc_prices:
     print(f"APCs offered in {len(source.apc_prices)} currencies:")
@@ -72,7 +78,7 @@ else:
 stats = source.summary_stats
 if stats:
     # Impact factor (2-year mean citedness)
-    print(f"Impact Factor: {stats['2yr_mean_citedness']:.3f}")
+    print(f"Impact Factor: {stats.two_year_mean_citedness:.3f}")
     
     # H-index for the source
     print(f"H-index: {stats.h_index}")
@@ -81,7 +87,7 @@ if stats:
     print(f"i10-index: {stats.i10_index:,}")
     
     # Interpret the metrics
-    if stats['2yr_mean_citedness'] > 10:
+    if stats.two_year_mean_citedness and stats.two_year_mean_citedness > 10:
         print("This is a high-impact journal")
 ```
 
@@ -235,8 +241,8 @@ def compare_sources(source_ids):
     
     for src in sources:
         impact_factor = "N/A"
-        if src.summary_stats and '2yr_mean_citedness' in src.summary_stats:
-            impact_factor = f"{src.summary_stats['2yr_mean_citedness']:.2f}"
+        if src.summary_stats and src.summary_stats.two_year_mean_citedness:
+            impact_factor = f"{src.summary_stats.two_year_mean_citedness:.2f}"
         
         apc = "N/A"
         if src.apc_usd is not None:
@@ -283,8 +289,8 @@ def find_related_sources(source_id):
         print(f"  - {src.display_name}")
     
     # Find sources with similar impact
-    if source.summary_stats and '2yr_mean_citedness' in source.summary_stats:
-        impact = source.summary_stats['2yr_mean_citedness']
+    if source.summary_stats and source.summary_stats.two_year_mean_citedness:
+        impact = source.summary_stats.two_year_mean_citedness
         min_impact = impact * 0.7
         max_impact = impact * 1.3
         
@@ -300,7 +306,7 @@ def find_related_sources(source_id):
         
         print(f"\nWith similar impact factor ({impact:.1f}):")
         for src in similar_impact.results[:5]:
-            src_if = src.summary_stats['2yr_mean_citedness']
+            src_if = src.summary_stats.two_year_mean_citedness
             print(f"  - {src.display_name} (IF: {src_if:.1f})")
 
 # Find sources related to Nature
@@ -319,8 +325,8 @@ else:
     print("No homepage listed")
 
 # Handle missing statistics
-if source.summary_stats and '2yr_mean_citedness' in source.summary_stats:
-    print(f"Impact Factor: {source.summary_stats['2yr_mean_citedness']:.3f}")
+if source.summary_stats and source.summary_stats.two_year_mean_citedness:
+    print(f"Impact Factor: {source.summary_stats.two_year_mean_citedness:.3f}")
 else:
     print("Impact Factor not calculated")
 
@@ -361,7 +367,6 @@ if work.primary_location and work.primary_location.source:
     print(source.type)
     print(source.is_oa)
     print(source.is_in_doaj)
-    print(source.is_core)
     print(source.host_organization)
     print(source.host_organization_name)
     print(source.issn_l)


### PR DESCRIPTION
## Summary
- correct pagination and sorting examples for Sources docs
- switch to host_organization grouping fields
- update examples for range filtering and missing imports
- use valid field accessors for summary stats

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f92b4cb5c832b948a08d90e8d22c4