### PR TITLE
Fix documentation examples for source usage

### DIFF
--- a/docs/sources/filter-sources.md
+++ b/docs/sources/filter-sources.md
@@ -305,7 +305,11 @@ def find_affordable_oa_journals(max_apc=1500, min_impact=2.0):
     print(f"Affordable OA journals (APC < ${max_apc}, IF > {min_impact}):")
     for journal in affordable_oa.results:
         apc = journal.apc_usd or 0
-        impact = journal.summary_stats["2yr_mean_citedness"]
+        impact = (
+            journal.summary_stats.get("2yr_mean_citedness")
+            if isinstance(journal.summary_stats, dict)
+            else journal.summary_stats.two_year_mean_citedness
+        )
         print(f"\n{journal.display_name}")
         print(f"  APC: ${apc}")
         print(f"  Impact Factor: {impact:.2f}")

--- a/docs/sources/get-lists-of-sources.md
+++ b/docs/sources/get-lists-of-sources.md
@@ -66,7 +66,7 @@ alphabetical = Sources().sort(display_name="asc").get()
 # Get ALL sources (feasible with ~249,000)
 # This will make about 1,250 API calls at 200 per page
 all_sources = []
-for source in Sources().paginate(per_page=200, max_results=12000):
+for source in Sources().paginate(per_page=200, cursor="*", max_results=12000):
     all_sources.append(source)
 print(f"Fetched {len(all_sources)} sources")
 ```
@@ -147,7 +147,7 @@ high_impact_journals = (
     .filter(type="journal")
     .filter_gt(summary_stats={"2yr_mean_citedness": 5.0})
     .filter_gt(works_count=1000)
-    .sort(summary_stats={"2yr_mean_citedness": "desc"})
+    .sort(**{"summary_stats.2yr_mean_citedness": "desc"})
     .get(per_page=20)
 )
 

--- a/docs/sources/group-sources.md
+++ b/docs/sources/group-sources.md
@@ -160,7 +160,7 @@ doaj_apcs = (
 european_publishers = (
     Sources()
     .filter(continent="europe")
-    .group_by("host_organization_name")
+    .group_by("host_organization")
     .get()
 )
 ```
@@ -180,9 +180,7 @@ country_type = Sources().group_by("country_code", "type").get()
 
 # This shows which countries have which types of sources
 for group in country_type.group_by[:20]:
-    # Keys are pipe-separated for multi-dimensional groups
-    country, source_type = group.key.split('|')
-    print(f"{country} - {source_type}: {group.count}")
+    print(f"{group.key}: {group.count}")
 
 # Publisher and source type
 # Group by host organization and source type

--- a/docs/sources/search-sources.md
+++ b/docs/sources/search-sources.md
@@ -211,7 +211,11 @@ def find_sources_by_topic(topic, source_type=None):
         print(f"   Type: {source.type}")
         print(f"   Works: {source.works_count:,}")
         if source.summary_stats and source.type == "journal":
-            impact = source.summary_stats.two_year_mean_citedness or 0
+            impact = (
+                source.summary_stats.get("2yr_mean_citedness", 0)
+                if isinstance(source.summary_stats, dict)
+                else source.summary_stats.two_year_mean_citedness or 0
+            )
             print(f"   Impact Factor: {impact:.2f}")
 
 # Examples
@@ -348,7 +352,11 @@ def comprehensive_journal_search(search_terms, min_impact=None):
         for source in results.results:
             # Apply additional filters
             if min_impact and source.summary_stats:
-                impact = source.summary_stats.two_year_mean_citedness or 0
+                impact = (
+                    source.summary_stats.get("2yr_mean_citedness", 0)
+                    if isinstance(source.summary_stats, dict)
+                    else source.summary_stats.two_year_mean_citedness or 0
+                )
                 if impact < min_impact:
                     continue
             


### PR DESCRIPTION
## Summary
- correct pagination example for large source lists
- fix sorting syntax in high-impact journals example
- guard against dict summary stats in examples
- clean up grouping and source object usage

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fa2a80b10832bac3fb5fd380dfa89