### PR TITLE
Fix docs examples and null APC prices

### DIFF
--- a/docs/sources/get-lists-of-sources.md
+++ b/docs/sources/get-lists-of-sources.md
@@ -153,7 +153,7 @@ high_impact_journals = (
 
 print("Top 20 high-impact journals (IF > 5.0):")
 for i, journal in enumerate(high_impact_journals.results, 1):
-    impact_factor = journal.summary_stats["2yr_mean_citedness"]
+    impact_factor = journal.summary_stats.two_year_mean_citedness
     print(f"{i}. {journal.display_name}")
     print(f"   Impact Factor: {impact_factor:.2f}")
     print(f"   Works: {journal.works_count:,}")

--- a/docs/sources/source-object.md
+++ b/docs/sources/source-object.md
@@ -158,12 +158,13 @@ if source.x_concepts:
 ## Works API URL
 
 ```python
+from openalex import Sources, Works
+
+source = Sources()["S137773608"]
 # URL to get all works from this source
 print(f"Works URL: {source.works_api_url}")
 
 # To actually fetch works using the client:
-from openalex import Sources, Works
-source = Sources()["S137773608"]
 
 # Get recent works from this source
 source_works = (

--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -104,6 +104,16 @@ class Source(OpenAlexEntity):
     apc_prices: list[APCPrice] = Field(
         default_factory=list, description="Article processing charges"
     )
+
+    @field_validator("apc_prices", mode="before")
+    @classmethod
+    def _normalize_apc_prices(
+        cls, value: Any
+    ) -> list[APCPrice] | Any:
+        """Convert ``None`` to an empty list for APC prices."""
+        if value is None:
+            return []
+        return value
     apc_usd: int | None = Field(None, description="APC in USD")
 
     country_code: str | None = Field(None, description="Country code")


### PR DESCRIPTION
## Summary
- handle `None` `apc_prices` when parsing Source data
- fix high impact journals example
- correct works API URL example order

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`
- `pytest tests/docs/test_sources.py --docs -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa84b6c48832b8279ca3fc85d3f4f