### PR TITLE
Fix society parsing for sources

### DIFF
--- a/openalex/models/source.py
+++ b/openalex/models/source.py
@@ -37,9 +37,11 @@ class APCPrice(OpenAlexBase):
     currency: str | None = None
 
 
-class Society(OpenAlexEntity):
-    """Society affiliation."""
+class Society(OpenAlexBase):
+    """Society affiliation information."""
 
+    id: str | None = None
+    display_name: str | None = None
     url: str | None = None
     organization: str | None = None
 


### PR DESCRIPTION
## Summary
- handle societies without id/display_name data in Source model

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`
- `pytest tests/docs/test_sources.py --docs -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb614b74c832baec3baeacc815863