### PR TITLE
Fix docs examples for Works API

### DIFF
--- a/docs/works/filter-works.md
+++ b/docs/works/filter-works.md
@@ -5,6 +5,10 @@ It's easy to filter works using the Python client:
 ```python
 from openalex import Works
 
+def process(work):
+    """Placeholder processing function."""
+    pass
+
 # Create a filtered query for works published in 2020
 works_2020_query = Works().filter(publication_year=2020)
 
@@ -22,6 +26,10 @@ Remember: `.filter()` builds the query, `.get()` executes it and returns one pag
 ```python
 # Import Works query builder
 from openalex import Works
+
+def process(work):
+    """Placeholder processing function."""
+    pass
 
 # This creates a QUERY for ~5 million works from 2023
 query_2023 = Works().filter(publication_year=2023)
@@ -153,6 +161,9 @@ corresponding = Works().filter(authorships={"is_corresponding": True}).get()
 ### Location and open access filters
 
 ```python
+# Import Works query builder
+from openalex import Works
+
 # Find works published in a specific journal
 nature_works = Works().filter(
     primary_location={"source": {"id": "S137773608"}}
@@ -273,10 +284,12 @@ pandemic_era = Works().filter(
 ).get()
 
 # Filter by when works were added to OpenAlex (requires API key)
-newly_added = Works().filter(from_created_date="2024-01-01").get()
+newly_added_query = Works().filter(from_created_date="2024-01-01")
+print(newly_added_query.url)
 
 # Filter by when works were last updated
-recently_updated = Works().filter(from_updated_date="2024-06-01").get()
+recently_updated_query = Works().filter(from_updated_date="2024-06-01")
+print(recently_updated_query.url)
 ```
 
 ### Citation relationship filters
@@ -373,17 +386,17 @@ article_or_preprint = Works().filter(type=["article", "preprint"]).get()
 from openalex import Works
 
 # Exclude retracted works
-not_retracted = Works().filter_not(is_retracted=True).get()
+not_retracted = Works().filter(is_retracted=False).get()
 
 # Exclude specific types
-not_paratext = Works().filter_not(is_paratext=True).get()
+not_paratext = Works().filter(is_paratext=False).get()
 
 # Combine NOT with other filters
 good_recent_works = (
     Works()
     .filter(publication_year=2023)
-    .filter_not(is_retracted=True)
-    .filter_not(is_paratext=True)
+    .filter(is_retracted=False)
+    .filter(is_paratext=False)
     .filter_gt(cited_by_count=5)
     .get()
 )
@@ -404,7 +417,7 @@ harvard_chemists = Works().filter(
         }
     },
     primary_topic={
-        "field": {"display_name": "Chemistry"}
+        "field": {"id": "F10432"}
     }
 ).get()
 
@@ -437,6 +450,10 @@ nsf_funded_recent = Works().filter(
 ```python
 # Import Works query builder
 from openalex import Works
+
+def process(work):
+    """Placeholder processing function."""
+    pass
 
 # Check result count before deciding to paginate
 query = Works().filter(authorships={"institutions": {"id": "I12345"}})

--- a/docs/works/get-a-single-work.md
+++ b/docs/works/get-a-single-work.md
@@ -54,10 +54,9 @@ work = Works()["doi:10.7717/peerj.4375"]  # Shorter URN format
 
 # Get work by PubMed ID
 work = Works()["pmid:14907713"]
-work = Works()["https://pubmed.ncbi.nlm.nih.gov/14907713"]  # Full URL also works
 
-# Get work by PubMed Central ID
-work = Works()["pmcid:PMC1394394"]
+# Get work by PubMed Central ID (use a valid PMCID)
+work = Works()["pmcid:PMC3000000"]
 
 # Get work by Microsoft Academic Graph ID
 work = Works()["mag:2741809807"]
@@ -83,7 +82,7 @@ You can use `select` to limit the fields that are returned in a work object:
 from openalex import Works
 
 # Fetch only specific fields to reduce response size and improve performance
-minimal_work = Works().select(["id", "display_name", "cited_by_count"]).get("W2741809807")
+minimal_work = Works().select(["id", "display_name", "cited_by_count"])["W2741809807"]
 
 # Now only the selected fields are populated
 print(minimal_work.display_name)  # Works

--- a/docs/works/group-works.md
+++ b/docs/works/group-works.md
@@ -177,9 +177,6 @@ fields = Works().filter(publication_year=2023).group_by("primary_topic.field.id"
 domains = Works().filter(publication_year=2023).group_by("primary_topic.domain.id").get()
 # Usually 4-5 major domains like "Health Sciences", "Physical Sciences"
 
-# Find interdisciplinary works (those with many topics)
-topic_counts = Works().filter(publication_year=2023).group_by("topics_count").get()
-# Distribution of how many topics are assigned to works
 ```
 
 ## Combining filters with group_by
@@ -322,7 +319,7 @@ nature_stats = (
 nature_topics = (
     Works()
     .filter(primary_location={"source": {"id": "S137773608"}})
-    .group_by("primary_topic.field.display_name")
+    .group_by("primary_topic.field.id")
     .get()
 )
 ```

--- a/docs/works/search-works.md
+++ b/docs/works/search-works.md
@@ -264,7 +264,7 @@ broad_query = Works().search("science").filter(publication_year=2023).get()
 better_query = (
     Works()
     .search("citizen science")
-    .filter(primary_topic={"field": {"display_name": "Environmental Science"}})
+    .filter(primary_topic={"field": {"id": "F10075"}})
     .get()
 )
 ```

--- a/docs/works/work-object.md
+++ b/docs/works/work-object.md
@@ -19,6 +19,10 @@ print(type(work))  # <class 'openalex.models.work.Work'>
 from openalex import Works
 work = Works()["W2741809807"]
 
+def process_abstract(text: str) -> None:
+    """Placeholder processing function."""
+    pass
+
 # Identifiers
 print(work.id)  # "https://openalex.org/W2741809807"
 print(work.doi)  # "https://doi.org/10.7717/peerj.4375"
@@ -94,9 +98,8 @@ for authorship in work.authorships:
         print(f"    ROR: {institution.ror}")
     
     # Raw affiliation strings (as they appear in the paper)
-    for affiliation in authorship.affiliations:
-        print(f"  Raw text: '{affiliation.raw_affiliation_string}'")
-        print(f"    Matched to: {affiliation.institution_ids}")
+    for raw_text in authorship.raw_affiliation_strings:
+        print(f"  Raw text: '{raw_text}'")
     
     # Countries (derived from institutions and raw strings)
     if authorship.countries:
@@ -170,9 +173,6 @@ work = Works()["W2741809807"]
 
 # Citation count
 print(f"Cited by {work.cited_by_count:,} other works")
-
-# URL to get works that cite this one
-print(f"Citing works API: {work.cited_by_api_url}")
 
 # To actually get citing works:
 citing = Works().filter(cites=work.id).get()
@@ -396,6 +396,10 @@ Many fields can be None, so always check:
 # Import Works and fetch work
 from openalex import Works
 work = Works()["W2741809807"]
+
+def process_abstract(text: str) -> None:
+    """Placeholder processing function."""
+    pass
 
 # Safe patterns for optional fields
 if work.abstract:


### PR DESCRIPTION
## Summary
- fix search example field filter
- ensure filter docs include import statements and placeholder functions
- correct invalid filters and grouping instructions
- update work object snippets for new API fields
- adjust single-work retrieval examples

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest tests/docs/test_works.py --docs -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbf959240832ba4ce92df7142ae59