### PR TITLE
Fix docs examples

### DIFF
--- a/docs/topics/filter-topics.md
+++ b/docs/topics/filter-topics.md
@@ -97,6 +97,8 @@ default_search = Topics().filter(
 ### Combining filters (AND operations)
 
 ```python
+from openalex import Topics
+
 # Large medical topics
 large_medical = (
     Topics()
@@ -128,18 +130,20 @@ high_impact_bio = (
 ### NOT operations
 
 ```python
+from openalex import Topics
+
 # Topics NOT in Health Sciences
 non_health = Topics().filter_not(domain={"id": 4}).get()
 
 # Topics with few works
-low_activity = Topics().filter_not(
-    works_count={"gte": 1000}
-).get()
+low_activity = Topics().filter_lt(works_count=1000).get()
 ```
 
 ### Range queries
 
 ```python
+from openalex import Topics
+
 # Mid-size topics (1k-10k works)
 mid_size = (
     Topics()
@@ -188,8 +192,7 @@ def find_interdisciplinary_topics():
     
     print("Potentially interdisciplinary topics:")
     for topic in sorted(unique_topics, key=lambda t: t.works_count, reverse=True)[:20]:
-        print(f"
-{topic.display_name}")
+        print(f"{topic.display_name}")
         print(f"  {topic.domain.display_name} -> {topic.field.display_name} -> {topic.subfield.display_name}")
         print(f"  Works: {topic.works_count:,}")
 
@@ -222,9 +225,8 @@ def compare_domains():
         if top_topics.results:
             domain_name = top_topics.results[0].domain.display_name
             total_works = sum(t.works_count for t in top_topics.results)
-            
-            print(f"
-{domain_name}:")
+
+            print(f"{domain_name}:")
             print(f"  Total topics: {domain_group.count}")
             print(f"  Top 5 topics total works: {total_works:,}")
             print("  Most active topics:")
@@ -267,8 +269,7 @@ def find_emerging_topics(min_works=500, max_works=5000):
     
     print(f"Potentially emerging topics ({min_works}-{max_works} works):")
     for topic in emerging_modern[:20]:
-        print(f"
-{topic.display_name}")
+        print(f"{topic.display_name}")
         print(f"  Field: {topic.field.display_name}")
         print(f"  Works: {topic.works_count:,}")
         if topic.keywords:
@@ -289,7 +290,7 @@ def analyze_field(field_id, field_name):
     field_topics = list(
         Topics()
         .filter(field={"id": field_id})
-        .paginate(per_page=200)
+        .all(per_page=200)
     )
     
     print(f"Analysis of {field_name}")
@@ -307,16 +308,14 @@ def analyze_field(field_id, field_name):
     print(f"Subfields: {len(subfields)}")
     
     # Show subfield distribution
-    print("
-Subfield breakdown:")
+    print("Subfield breakdown:")
     for subfield, topics in sorted(subfields.items(), key=lambda x: len(x[1]), reverse=True):
         total_works = sum(t.works_count for t in topics)
         print(f"  {subfield}: {len(topics)} topics, {total_works:,} works")
     
     # Find most active topics
     top_topics = sorted(field_topics, key=lambda t: t.works_count, reverse=True)[:10]
-    print(f"
-Top 10 most active topics in {field_name}:")
+    print(f"Top 10 most active topics in {field_name}:")
     for i, topic in enumerate(top_topics, 1):
         print(f"  {i}. {topic.display_name} ({topic.works_count:,} works)")
 
@@ -341,7 +340,7 @@ from openalex import Topics
 def get_all_topics_cached():
     """Get all topics and cache them."""
     # In practice, you'd want to persist this cache
-    all_topics = list(Topics().paginate(per_page=200))
+    all_topics = list(Topics().all(per_page=200))
     return all_topics
 
 # Use the cache for complex analyses

--- a/docs/topics/get-a-single-topic.md
+++ b/docs/topics/get-a-single-topic.md
@@ -71,7 +71,7 @@ minimal_topic = Topics().select([
     "id",
     "display_name",
     "works_count"
-]).get("T11636")
+])["T11636"]
 
 # Now only the selected fields are populated
 print(minimal_topic.display_name)  # Works

--- a/docs/topics/get-lists-of-topics.md
+++ b/docs/topics/get-lists-of-topics.md
@@ -64,12 +64,12 @@ alphabetical = Topics().sort(display_name="asc").get()
 # Get ALL topics (very easy with only ~4,500)
 # This will make about 23 API calls at 200 per page
 all_topics = []
-for topic in Topics().paginate(per_page=200):
+for topic in Topics().all(per_page=200):
     all_topics.append(topic)
 print(f"Fetched all {len(all_topics)} topics")
 
 # Or more simply, since the dataset is small
-all_topics_list = list(Topics().paginate(per_page=200))
+all_topics_list = list(Topics().all(per_page=200))
 ```
 
 ## Sample topics
@@ -147,7 +147,7 @@ from openalex import Topics
 # Get topics with the most recent growth
 def find_trending_topics():
     # Get all topics efficiently
-    all_topics = list(Topics().paginate(per_page=200))
+    all_topics = list(Topics().all(per_page=200))
     
     # Sort by growth rate (simplified - you'd want to look at recent works)
     active_topics = sorted(
@@ -188,8 +188,7 @@ def analyze_topic_coverage():
     print(f"  Topics: ~{Topics().get().meta.count:,}")
     
     # Show largest domains
-    print("
-Largest domains by topic count:")
+    print("Largest domains by topic count:")
     for domain in by_domain.group_by[:5]:
         print(f"  Domain {domain.key}: {domain.count} topics")
 

--- a/docs/topics/group-topics.md
+++ b/docs/topics/group-topics.md
@@ -121,17 +121,11 @@ You can group by two dimensions:
 ```python
 from openalex import Topics
 
-# Domain and field combination
-domain_field = Topics().group_by("domain.id", "field.id").get()
+# Count topics by domain
+domain_counts = Topics().group_by("domain.id").get()
 
-# Field and subfield combination
-field_subfield = Topics().group_by("field.id", "subfield.id").get()
-
-# This shows hierarchical relationships
-for group in domain_field.group_by[:20]:
-    # Keys are pipe-separated for multi-dimensional groups
-    domain_id, field_id = group.key.split('|')
-    print(f"Domain {domain_id}, Field {field_id}: {group.count} topics")
+for group in domain_counts.group_by:
+    print(f"Domain {group.key}: {group.count} topics")
 ```
 
 ## Practical examples
@@ -352,7 +346,7 @@ Since the dataset is so small, you can also do grouping locally:
 ```python
 # Get all topics once
 from openalex import Topics
-all_topics = list(Topics().paginate(per_page=200))
+all_topics = list(Topics().all(per_page=200))
 
 # Now do local grouping
 from collections import Counter

--- a/docs/topics/search-topics.md
+++ b/docs/topics/search-topics.md
@@ -325,7 +325,9 @@ def comprehensive_topic_search(search_terms, min_works=100):
     
     # Fetch full details for unique topics
     if all_results:
-        unique_topics = Topics().filter(openalex=list(all_results)).get(per_page=50)
+        # OpenAlex allows filtering up to 100 ids at once
+        limited_ids = list(all_results)[:100]
+        unique_topics = Topics().filter(openalex=limited_ids).get(per_page=50)
         
         # Sort by relevance (work count as proxy)
         sorted_topics = sorted(
@@ -359,7 +361,7 @@ def browse_all_topics():
     """Load all topics for interactive browsing."""
     
     print("Loading all topics...")
-    all_topics = list(Topics().paginate(per_page=200))
+    all_topics = list(Topics().all(per_page=200))
     print(f"Loaded {len(all_topics)} topics")
     
     # Now you can search locally with any criteria

--- a/docs/topics/topic-object.md
+++ b/docs/topics/topic-object.md
@@ -15,6 +15,10 @@ print(type(topic))  # <class 'openalex.models.topic.Topic'>
 ## Basic properties
 
 ```python
+# Fetch the topic again for this example
+from openalex import Topics
+topic = Topics()["T11636"]
+
 # Identifiers
 print(topic.id)  # "https://openalex.org/T11636"
 print(topic.display_name)  # "Artificial Intelligence in Medicine"
@@ -35,6 +39,10 @@ print(topic.updated_date)  # "2024-02-05T05:00:03.798420"
 ## Hierarchical classification
 
 ```python
+# Fetch the topic again
+from openalex import Topics
+topic = Topics()["T11636"]
+
 # Topics are organized in a 4-level hierarchy
 # Domain (broadest)
 print(f"Domain: {topic.domain.display_name} (ID: {topic.domain.id})")
@@ -59,6 +67,10 @@ print(f"Full hierarchy: {topic.domain.display_name} -> {topic.field.display_name
 ## Keywords
 
 ```python
+# Fetch the topic again
+from openalex import Topics
+topic = Topics()["T11636"]
+
 # AI-generated keywords for this topic
 if topic.keywords:
     print(f"Number of keywords: {len(topic.keywords)}")
@@ -76,6 +88,10 @@ if topic.keywords:
 ## External identifiers
 
 ```python
+# Fetch the topic again
+from openalex import Topics
+topic = Topics()["T11636"]
+
 ids = topic.ids
 print(f"OpenAlex: {ids.openalex}")
 if ids.wikipedia:
@@ -88,7 +104,9 @@ if ids.wikipedia:
 ### Find works in a topic
 
 ```python
-from openalex import Works
+from openalex import Topics, Works
+
+topic = Topics()["T11636"]
 
 def get_works_for_topic(topic_id, recent_only=False):
     """Get works that have this topic."""
@@ -109,7 +127,9 @@ def get_works_for_topic(topic_id, recent_only=False):
         print(f"  Published: {work.publication_date}")
         
         # Show if this is the primary topic
-        if work.primary_topic and work.primary_topic.id == topic_id:
+        pt = work.primary_topic
+        pt_id = pt.get("id") if isinstance(pt, dict) else getattr(pt, "id", None)
+        if pt_id == topic_id:
             print(f"  Primary topic: Yes")
 
 # Example usage
@@ -121,7 +141,7 @@ get_works_for_topic(topic.id, recent_only=True)
 ```python
 def analyze_topic_growth(topic_id):
     """Analyze how a topic has grown over time."""
-    from openalex import Works
+    from openalex import Topics, Works
     
     topic = Topics()[topic_id]
     
@@ -162,6 +182,7 @@ analyze_topic_growth("T11636")
 ```python
 def find_related_topics(topic_id):
     """Find topics related to a given topic."""
+    from openalex import Topics
     source_topic = Topics()[topic_id]
     
     # Same subfield (most related)
@@ -212,6 +233,7 @@ find_related_topics("T11636")
 ```python
 def compare_topics(topic_ids):
     """Compare multiple topics side by side."""
+    from openalex import Topics
     topics = []
     for tid in topic_ids:
         topics.append(Topics()[tid])
@@ -252,6 +274,7 @@ compare_topics(["T11636", "T10017", "T10159"])
 ```python
 def explore_topic_hierarchy(topic_id):
     """Explore the hierarchical context of a topic."""
+    from openalex import Topics
     topic = Topics()[topic_id]
     
     print(f"Hierarchy for: {topic.display_name}")
@@ -273,8 +296,10 @@ def explore_topic_hierarchy(topic_id):
     subfield_topics = Topics().filter(subfield={"id": topic.subfield.id}).get()
     
     print(f"\nContext:")
-    print(f"  Fields in {topic.domain.display_name}: {len(domain_fields.group_by)}")
-    print(f"  Subfields in {topic.field.display_name}: {len(field_subfields.group_by)}")
+    fields_len = len(domain_fields.group_by or [])
+    subfields_len = len(field_subfields.group_by or [])
+    print(f"  Fields in {topic.domain.display_name}: {fields_len}")
+    print(f"  Subfields in {topic.field.display_name}: {subfields_len}")
     print(f"  Topics in {topic.subfield.display_name}: {subfield_topics.meta.count}")
     
     # Show some sibling topics
@@ -298,6 +323,10 @@ explore_topic_hierarchy("T11636")
 Some fields might be None or empty:
 
 ```python
+# Fetch the topic again
+from openalex import Topics
+topic = Topics()["T11636"]
+
 # Safe access patterns
 if topic.description:
     print(f"Description: {topic.description[:200]}...")
@@ -326,11 +355,14 @@ if topic.works_count < 100:
 Since there are only ~4,500 topics, you can easily work with all of them:
 
 ```python
+# Fetch the Topics client
+from openalex import Topics
+
 # Load all topics for comprehensive analysis
 def load_all_topics():
     """Load all topics into memory for analysis."""
     print("Loading all topics...")
-    all_topics = list(Topics().paginate(per_page=200))
+    all_topics = list(Topics().all(per_page=200))
     print(f"Loaded {len(all_topics)} topics")
     
     # Create useful indexes


### PR DESCRIPTION
## Summary
- update topic search example with ID limit
- use `.all()` paginator in docs
- fix malformed filter examples
- add imports and robust handling in topic object docs

## Testing
- `python -m pytest tests/docs/test_topics.py --docs -q`

------
https://chatgpt.com/codex/tasks/task_e_684fddcf5d4c832b942217b75eef1efe