### PR TITLE
Trim heavy API calls in docs

### DIFF
--- a/docs/authors/filter-authors.md
+++ b/docs/authors/filter-authors.md
@@ -35,7 +35,7 @@ page2 = query_orcid.get(page=2, per_page=100)  # Authors 101-200
 page_count = 0
 for page in query_orcid.paginate(per_page=200):
     page_count += 1
-    if page_count > 10:  # Stop after 2,000 authors
+    if page_count > 2:  # Stop after about 400 authors
         break
     for author in page.results:
         print(author.id)
@@ -283,11 +283,13 @@ from openalex import Authors
 query = Authors().filter(last_known_institutions={"country_code": "US"})
 first_page = query.get()
 
-if first_page.meta.count > 100000:
+if first_page.meta.count > 10000:
     print(f"Warning: {first_page.meta.count:,} results!")
     print("Consider adding more filters or using group_by")
 else:
     # Safe to paginate through results
-    for author in query.paginate():
+    for i, author in enumerate(query.paginate(), 1):
         process(author)
+        if i >= 1000:
+            break
 ```

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,7 +1,7 @@
 # Concepts
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 Concepts are abstract ideas that works are about. OpenAlex indexes about 65k concepts.
@@ -9,7 +9,6 @@ Concepts are abstract ideas that works are about. OpenAlex indexes about 65k con
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Create a query builder for concepts
 concepts_query = Concepts()
 
@@ -20,7 +19,7 @@ print(f"Total concepts in OpenAlex: {first_page.meta.count:,}")  # ~65,000
 print(f"Concepts returned in this page: {len(first_page.results)}")  # 25
 
 # Show deprecation warning
-print("\n⚠️ WARNING: Concepts are deprecated. Use Topics instead!")
+print("\nWARNING: Concepts are deprecated. Use Topics instead!")
 ```
 
 The [Canonical External ID](../../how-to-use-the-api/get-single-entities/#canonical-external-ids) for OpenAlex concepts is the Wikidata ID, and each of our concepts has one, because all OpenAlex concepts are also Wikidata concepts.

--- a/docs/concepts/concept-object.md
+++ b/docs/concepts/concept-object.md
@@ -1,7 +1,7 @@
 # Concept object
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 When you fetch a concept using the Python client, you get a `Concept` object with all of OpenAlex's data about that concept. Here's how to access the various properties:
@@ -9,7 +9,6 @@ When you fetch a concept using the Python client, you get a `Concept` object wit
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get a specific concept
 concept = Concepts()["C71924100"]
 
@@ -23,7 +22,6 @@ print(type(concept))  # <class 'openalex.models.concept.Concept'>
 # Import client and fetch a concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Identifiers
 print(concept.id)  # "https://openalex.org/C71924100"
 print(concept.wikidata)  # "https://www.wikidata.org/wiki/Q11190" (canonical ID)
@@ -48,7 +46,6 @@ print(concept.updated_date)  # "2021-12-25T14:04:30.578837"
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Ancestors (concepts this descends from)
 if concept.ancestors:
     print(f"Ancestors ({len(concept.ancestors)}):")
@@ -71,7 +68,6 @@ if concept.related_concepts:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 stats = concept.summary_stats
 if stats:
     print(f"H-index: {stats.h_index}")
@@ -89,7 +85,6 @@ if stats:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Track output over the last 10 years
 print("Publication trends:")
 for count in concept.counts_by_year[:5]:  # Last 5 years
@@ -112,7 +107,6 @@ if len(concept.counts_by_year) >= 2:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 ids = concept.ids
 print(f"OpenAlex: {ids.openalex}")
 print(f"Wikidata: {ids.wikidata}")  # Always present (canonical ID)
@@ -132,7 +126,6 @@ if ids.umls_aui:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Concept visualization (usually from Wikipedia)
 if concept.image_url:
     print(f"Image URL: {concept.image_url}")
@@ -147,7 +140,6 @@ if concept.image_thumbnail_url:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Names in different languages
 if hasattr(concept, 'international') and concept.international:
     if hasattr(concept.international, 'display_name'):
@@ -162,7 +154,6 @@ if hasattr(concept, 'international') and concept.international:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # URL to get all works tagged with this concept
 print(f"Works URL: {concept.works_api_url}")
 
@@ -190,7 +181,6 @@ for work in concept_works.results[:5]:
 ```python
 # Import client
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def explore_concept_tree(concept_id):
     """Navigate up and down the concept hierarchy."""
     
@@ -235,7 +225,6 @@ explore_concept_tree("C41008148")  # Computer Science
 ```python
 # Import client
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_concept_impact(concept_id):
     """Comprehensive impact analysis of a concept."""
     concept = Concepts()[concept_id]
@@ -281,7 +270,6 @@ analyze_concept_impact("C154945302")  # Machine learning
 ```python
 # Import client
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def compare_concepts(concept_ids):
     """Compare multiple concepts side by side."""
     concepts = []
@@ -315,7 +303,6 @@ compare_concepts([
 ```python
 # Import client
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def find_concept_relationships(concept_id):
     """Find various relationships for a concept."""
     
@@ -371,7 +358,6 @@ Many fields can be None or empty:
 # Fetch concept
 from openalex import Concepts
 concept = Concepts()["C71924100"]
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Safe access patterns
 if concept.description:
     print(f"Description: {concept.description}")
@@ -403,7 +389,6 @@ if intl_names and hasattr(intl_names, 'display_name'):
 When concepts appear in other objects (like in work concepts or ancestors), you get a simplified version:
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get a work to see dehydrated concepts
 from openalex import Works
 from openalex import Concepts
@@ -424,5 +409,5 @@ if work.concepts:
         print(f"Full description: {full_concept.description}")
 ```
 
-**⚠️ Final reminder: Concepts are deprecated! Please migrate to [Topics](../topics/README.md) for better support and more accurate research classification.**
+**Final reminder: Concepts are deprecated! Please migrate to [Topics](../topics/README.md) for better support and more accurate research classification.**
 

--- a/docs/concepts/filter-concepts.md
+++ b/docs/concepts/filter-concepts.md
@@ -1,7 +1,7 @@
 # Filter concepts
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 You can filter concepts using the Python client:
@@ -9,7 +9,6 @@ You can filter concepts using the Python client:
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Create a filtered query for top-level concepts
 root_concepts_query = Concepts().filter(level=0)
 
@@ -35,7 +34,6 @@ You can filter using these attributes of the [`Concept`](concept-object.md) obje
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Filter by cited_by_count
 highly_cited = Concepts().filter(cited_by_count=1000000).get()  # Exactly 1M
 very_highly_cited = Concepts().filter_gt(cited_by_count=10000000).get()  # More than 10M
@@ -59,7 +57,6 @@ specific_ids = Concepts().filter(
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Filter by ancestors
 # Get all descendants of Computer Science (C41008148)
 cs_descendants = Concepts().filter(ancestors={"id": "C41008148"}).get()
@@ -83,7 +80,6 @@ interdisciplinary = (
 ### Summary statistics filters
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Filter by h-index
 high_h_index = Concepts().filter_gt(summary_stats={"h_index": 200}).get()
@@ -114,7 +110,6 @@ These filters aren't attributes of the Concept object, but they're handy:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Has Wikidata ID (currently all concepts have one)
 with_wikidata = Concepts().filter(has_wikidata=True).get()
 without_wikidata = Concepts().filter(has_wikidata=False).get()
@@ -126,7 +121,6 @@ print(f"Without Wikidata: {without_wikidata.meta.count:,}")  # Should be 0
 ### Text search filters
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Search in display names
 ai_search = Concepts().filter(
@@ -148,7 +142,6 @@ default_search = Concepts().filter(
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # High-impact computer science concepts
 high_impact_cs = (
     Concepts()
@@ -180,7 +173,6 @@ ml_concepts = (
 ### NOT operations
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Concepts NOT under Computer Science
 from openalex import Concepts
 non_cs = Concepts().filter_not(ancestors={"id": "C41008148"}).get()
@@ -197,7 +189,6 @@ low_impact = Concepts().filter_lt(
 ### Range queries
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Mid-level concepts (levels 2-4)
 mid_levels = (
@@ -221,7 +212,6 @@ moderate_activity = (
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def explore_concept_branch(concept_id, max_depth=3):
     """Explore a branch of the concept tree."""
     
@@ -259,7 +249,6 @@ explore_concept_branch("C41008148")
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def find_interdisciplinary_concepts():
     """Find concepts that bridge multiple fields."""
     
@@ -289,7 +278,6 @@ find_interdisciplinary_concepts()
 ### Example 3: Analyze research trends
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 def analyze_research_trends(min_works=50000):
     """Find rapidly growing research areas."""
@@ -338,7 +326,6 @@ analyze_research_trends()
 ### Example 4: Concept similarity
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 def find_similar_concepts(concept_id):
     """Find concepts similar to a given concept."""
@@ -381,7 +368,6 @@ Since there are ~65,000 concepts:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Example: Efficiently analyze concept distribution
 def concept_distribution_summary():
     # Use group_by instead of fetching all concepts
@@ -400,4 +386,4 @@ def concept_distribution_summary():
         print(f"  {root.display_name}: {descendants.meta.count:,} descendants")
 ```
 
-**⚠️ Final reminder: Concepts are deprecated! Please use [Topics](../topics/README.md) for all new projects.**
+**Final reminder: Concepts are deprecated! Please use [Topics](../topics/README.md) for all new projects.**

--- a/docs/concepts/get-a-single-concept.md
+++ b/docs/concepts/get-a-single-concept.md
@@ -1,7 +1,7 @@
 # Get a single concept
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 It's easy to get a concept using the Python client:
@@ -9,7 +9,6 @@ It's easy to get a concept using the Python client:
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get a specific concept by their OpenAlex ID
 concept = Concepts()["C71924100"]
 
@@ -40,7 +39,6 @@ You can make up to 50 of these queries at once by requesting a list of entities 
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Fetch multiple specific concepts in one API call
 concept_ids = ["C71924100", "C41008148", "C86803240"]
 multiple_concepts = Concepts().filter(openalex=concept_ids).get()
@@ -57,7 +55,6 @@ You can look up concepts using external IDs such as a Wikidata ID:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get concept by Wikidata ID (canonical external ID)
 medicine = Concepts()["wikidata:Q11190"]
 medicine = Concepts()["wikidata:https://www.wikidata.org/wiki/Q11190"]  # Full URL
@@ -79,7 +76,6 @@ You can use `select` to limit the fields that are returned in a concept object:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Fetch only specific fields to reduce response size
 minimal_concept = Concepts().select([
     "id",

--- a/docs/concepts/get-lists-of-concepts.md
+++ b/docs/concepts/get-lists-of-concepts.md
@@ -1,7 +1,7 @@
 # Get lists of concepts
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 You can get lists of concepts using the Python client:
@@ -9,7 +9,6 @@ You can get lists of concepts using the Python client:
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Create a query for all concepts (no filters applied)
 all_concepts_query = Concepts()
 
@@ -33,7 +32,6 @@ The response contains:
 from openalex import Concepts
 
 first_page = Concepts().get()
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Each result shows concept information
 for concept in first_page.results[:5]:  # First 5 concepts
     print(f"\n{concept.display_name} (Level {concept.level})")
@@ -51,7 +49,6 @@ You can control pagination and sorting:
 ```python
 # Import client
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get a specific page with custom page size
 page2 = Concepts().get(per_page=50, page=2)
 # This returns concepts 51-100
@@ -67,17 +64,16 @@ most_cited = Concepts().sort(cited_by_count="desc").get()
 root_concepts = Concepts().filter(level=0).sort(display_name="asc").get()
 print(f"Found {root_concepts.meta.count} root concepts")  # Should be 19
 
-# Get many concepts (feasible with ~65,000)
-# This example stops after about 1,000 concepts to avoid huge downloads
-all_concepts = []
+# Get many concepts without downloading everything
+some_concepts = []
 page_count = 0
 for page in Concepts().paginate(per_page=200):
     page_count += 1
-    if page_count > 5:  # Roughly 1,000 concepts
+    if page_count > 2:  # Roughly 400 concepts
         break
-    all_concepts.extend(page.results)
+    some_concepts.extend(page.results)
 
-print(f"Fetched {len(all_concepts)} concepts")
+print(f"Fetched {len(some_concepts)} concepts")
 ```
 
 ## Sample concepts
@@ -86,7 +82,6 @@ Get a random sample of concepts:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Get 10 random concepts
 random_sample = Concepts().sample(10).get(per_page=10)
 
@@ -108,7 +103,6 @@ Limit the fields returned to improve performance:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Request only specific fields
 minimal_concepts = Concepts().select([
     "id",
@@ -130,7 +124,6 @@ for concept in minimal_concepts.results:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def explore_concept_hierarchy():
     """Explore the 6-level concept hierarchy."""
     
@@ -160,7 +153,6 @@ explore_concept_hierarchy()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_concept_levels():
     """Analyze how concepts are distributed across levels."""
     
@@ -189,7 +181,6 @@ analyze_concept_levels()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def find_research_hotspots(min_works=10000):
     """Find highly active research concepts."""
     
@@ -213,4 +204,4 @@ find_research_hotspots()
 
 Continue on to learn how you can [filter](filter-concepts.md) and [search](search-concepts.md) lists of concepts.
 
-**⚠️ Remember: Concepts are deprecated! Use [Topics](../topics/README.md) for new projects.**
+**Remember: Concepts are deprecated! Use [Topics](../topics/README.md) for new projects.**

--- a/docs/concepts/group-concepts.md
+++ b/docs/concepts/group-concepts.md
@@ -1,7 +1,7 @@
 # Group concepts
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 You can group concepts to get aggregated statistics without fetching individual concept records:
@@ -9,7 +9,6 @@ You can group concepts to get aggregated statistics without fetching individual 
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Create a query that groups concepts by level
 level_stats_query = Concepts().group_by("level")
 
@@ -29,7 +28,6 @@ for group in level_stats.group_by:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 result = Concepts().group_by("level").get()
 
 print(result.results)  # Empty list - no individual concepts returned!
@@ -49,7 +47,6 @@ for group in result.group_by:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Group by level (0-5)
 by_level = Concepts().group_by("level").get()
 # Shows how concepts are distributed across hierarchy levels
@@ -68,7 +65,6 @@ by_wikidata = Concepts().group_by("has_wikidata").get()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Works count distribution
 works_dist = Concepts().group_by("works_count").get()
 # Note: Creates many groups (one per unique count)
@@ -93,7 +89,6 @@ Group_by becomes more insightful when combined with filters:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Level distribution for Computer Science descendants
 cs_levels = (
     Concepts()
@@ -133,7 +128,6 @@ only so it works in unauthenticated environments:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 level_ancestor = Concepts().group_by("level").get()
 
 for group in level_ancestor.group_by:
@@ -145,7 +139,6 @@ for group in level_ancestor.group_by:
 ### Example 1: Analyze concept hierarchy
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 def analyze_concept_hierarchy():
     """Comprehensive analysis of the concept tree structure."""
@@ -178,7 +171,6 @@ analyze_concept_hierarchy()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_research_activity():
     """Analyze how research activity is distributed across concepts."""
     
@@ -226,7 +218,6 @@ analyze_research_activity()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def analyze_concept_impact():
     """Analyze impact metrics across the concept hierarchy."""
     
@@ -272,7 +263,6 @@ analyze_concept_impact()
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def compare_domains():
     
     # Get all root concepts
@@ -323,7 +313,6 @@ Control how results are ordered:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Default: sorted by count (descending)
 default_sort = Concepts().group_by("level").get()
 # Most populous levels first
@@ -343,8 +332,7 @@ smallest_first = Concepts().group_by("ancestors.id").sort(count="asc").get()
 2. **Efficient for analytics**: Much faster than fetching all concepts
 3. **Limited dimensions**: Maximum 2 fields for grouping
 4. **Good for hierarchy analysis**: Understand the concept tree structure
-5. **DEPRECATED**: Remember to use Topics for new projects!
 
 When you need statistics about concepts, prefer `group_by()` over fetching and counting individual records.
 
-**⚠️ Final reminder: Concepts are deprecated! Please use [Topics](../topics/README.md) instead for all new development.**
+**Final reminder: Concepts are deprecated! Please use [Topics](../topics/README.md) instead for all new development.**

--- a/docs/concepts/search-concepts.md
+++ b/docs/concepts/search-concepts.md
@@ -1,7 +1,7 @@
 # Search concepts
 
 {% hint style="warning" %}
-⚠️ **DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
+**DEPRECATION WARNING**: These are the original OpenAlex Concepts, which are being deprecated in favor of [Topics](../topics/README.md). We will continue to provide these Concepts for Works, but we will not be actively maintaining, updating, or providing support for these concepts. Unless you have a good reason to be relying on them, we encourage you to look into [Topics](../topics/README.md) instead.
 {% endhint %}
 
 The best way to search for concepts is to use the `search` method, which searches the `display_name` and `description` fields:
@@ -9,7 +9,6 @@ The best way to search for concepts is to use the `search` method, which searche
 ```python
 from openalex import Concepts
 
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Search for concepts related to artificial intelligence
 ai_search = Concepts().search("artificial intelligence")
 
@@ -30,7 +29,6 @@ The search checks multiple fields:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # This searches display_name AND description
 ml_results = Concepts().search("machine learning").get()
 
@@ -50,7 +48,6 @@ Read more about search relevance, stemming, and boolean searches in the [search 
 You can also use search as a filter:
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Search only in display_name
 name_only = Concepts().filter(
@@ -80,7 +77,6 @@ Available search fields:
 Create a fast type-ahead search experience:
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Get autocomplete suggestions
 suggestions = Concepts().autocomplete("comp")
@@ -116,7 +112,6 @@ Search is most powerful when combined with filters:
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Search for AI concepts at specific levels
 ai_subfields = (
     Concepts()
@@ -160,7 +155,6 @@ emerging = (
 ### Finding concepts in a domain
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 def search_in_domain(search_term, domain_concept_id):
     """Search for concepts within a specific domain."""
@@ -192,7 +186,6 @@ search_in_domain("therapy", "C71924100")
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 def hierarchical_search(search_term):
     """Search at different levels of the hierarchy."""
     
@@ -217,7 +210,6 @@ hierarchical_search("network")
 ### Related concept discovery
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 def discover_related_concepts(concept_id):
     """Find concepts related to a given concept through various methods."""
@@ -262,7 +254,6 @@ discover_related_concepts("C154945302")  # Machine learning
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Bioinformatics, computational biology, etc.
 bio_comp = (
     Concepts()
@@ -292,7 +283,6 @@ env_econ = (
 
 ```python
 from openalex import Concepts
-# ⚠️ DEPRECATED: Consider using Topics instead
 # Find emerging concepts with specific terms
 emerging_tech = (
     Concepts()
@@ -322,7 +312,6 @@ climate_concepts = (
 5. **Check related concepts**: Explore the concept graph
 
 ```python
-# ⚠️ DEPRECATED: Consider using Topics instead
 from openalex import Concepts
 # Example: Comprehensive concept search
 def comprehensive_search(search_terms, min_works=1000):
@@ -361,4 +350,4 @@ comprehensive_search([
 ])
 ```
 
-**⚠️ Final reminder: Concepts are deprecated! Please migrate to [Topics](../topics/README.md) for better support and accuracy.**
+**Final reminder: Concepts are deprecated! Please migrate to [Topics](../topics/README.md) for better support and accuracy.**

--- a/docs/funders/get-lists-of-funders.md
+++ b/docs/funders/get-lists-of-funders.md
@@ -60,16 +60,15 @@ most_cited = Funders().sort(cited_by_count="desc").get()
 # Alphabetical by name
 alphabetical = Funders().sort(display_name="asc").get()
 
-# Get ALL funders (very feasible with ~32,000)
-# This will make about 160 API calls at 200 per page
-all_funders = []
+# Get several funders without too many API calls
+some_funders = []
 page_count = 0
 for page in Funders().paginate(per_page=200):
     page_count += 1
-    if page_count > 5:  # Stop after 1,000 funders
+    if page_count > 2:  # Stop after about 400 funders
         break
-    all_funders.extend(page.results)
-print(f"Fetched {len(all_funders)} funders")
+    some_funders.extend(page.results)
+print(f"Fetched {len(some_funders)} funders")
 ```
 
 ## Sample funders

--- a/docs/institutions/get-lists-of-institutions.md
+++ b/docs/institutions/get-lists-of-institutions.md
@@ -61,14 +61,13 @@ most_cited = Institutions().sort(cited_by_count="desc").get()
 # Alphabetical by name
 alphabetical = Institutions().sort(display_name="asc").get()
 
-# Get ALL institutions (feasible with ~109,000)
-# Limit to the first 1,000 to avoid huge downloads
-all_institutions = []
+# Get many institutions but keep it manageable
+some_institutions = []
 for institution in Institutions().paginate(per_page=200, cursor="*"):
-    all_institutions.append(institution)
-    if len(all_institutions) >= 1000:  # Stop after 1,000
+    some_institutions.append(institution)
+    if len(some_institutions) >= 200:  # Stop after 200 results
         break
-print(f"Fetched {len(all_institutions)} institutions")
+print(f"Fetched {len(some_institutions)} institutions")
 ```
 
 ## Sample institutions

--- a/docs/performance-guide.md
+++ b/docs/performance-guide.md
@@ -6,12 +6,6 @@ Tips for working efficiently with the OpenAlex client.
 
 ```python
 # Always filter the Works entity - it has 250M+ records
-
-# \u274c BAD - Too broad
-# from openalex import Works
-# all_works = Works().get()  # DON'T DO THIS!
-
-# \u2705 GOOD - Always filter
 from openalex import Works
 
 filtered_works = (
@@ -47,7 +41,7 @@ for page in query.paginate(per_page=200):  # Max allowed
     print(f"Processed {processed} works so far...")
     
     # Stop after reasonable number
-    if processed >= 10000:
+    if processed >= 1000:
         break
 
 print(f"Completed processing {processed} works")

--- a/docs/publishers/get-lists-of-publishers.md
+++ b/docs/publishers/get-lists-of-publishers.md
@@ -61,14 +61,13 @@ most_cited = Publishers().sort(cited_by_count="desc").get()
 # Alphabetical by name
 alphabetical = Publishers().sort(display_name="asc").get()
 
-# Get ALL publishers (feasible with only ~10,000)
-# This will make about 50 API calls
-all_publishers = []
+# Get many publishers without hitting the API too hard
+some_publishers = []
 for i, page in enumerate(Publishers().paginate(per_page=200)):
-    if i >= 5:  # Stop after ~1000 results
+    if i >= 2:  # Stop after about 400 results
         break
-    all_publishers.extend(page.results)
-print(f"Fetched {len(all_publishers)} publishers")
+    some_publishers.extend(page.results)
+print(f"Fetched {len(some_publishers)} publishers")
 ```
 
 ## Sample publishers

--- a/docs/sources/get-lists-of-sources.md
+++ b/docs/sources/get-lists-of-sources.md
@@ -63,12 +63,11 @@ high_impact = Sources().sort(**{"summary_stats.2yr_mean_citedness": "desc"}).get
 # Alphabetical by name
 alphabetical = Sources().sort(display_name="asc").get()
 
-# Get ALL sources (feasible with ~249,000)
-# This will make about 1,250 API calls at 200 per page
-all_sources = []
-for source in Sources().paginate(per_page=200, cursor="*", max_results=12000):
-    all_sources.append(source)
-print(f"Fetched {len(all_sources)} sources")
+# Fetch many sources (limit the total to avoid excessive calls)
+some_sources = []
+for source in Sources().paginate(per_page=200, cursor="*", max_results=400):
+    some_sources.append(source)
+print(f"Fetched {len(some_sources)} sources")
 ```
 
 ## Sample sources

--- a/docs/works/filter-works.md
+++ b/docs/works/filter-works.md
@@ -52,7 +52,7 @@ for i, work in enumerate(query_2023.paginate(per_page=10), 1):
 
 You can filter using these attributes of the [`Work`](work-object.md) object:
 
-\u26a0\ufe0f The `host_venue` and `alternate_host_venues` properties have been deprecated in favor of `primary_location` and `locations`.
+Note: The `host_venue` and `alternate_host_venues` properties have been deprecated in favor of `primary_location` and `locations`.
 
 ### Basic attribute filters
 
@@ -459,13 +459,13 @@ def process(work):
 query = Works().filter(authorships={"institutions": {"id": "I12345"}})
 first_page = query.get()
 
-if first_page.meta.count > 10000:
+if first_page.meta.count > 1000:
     print(f"Warning: {first_page.meta.count:,} results!")
     print("Consider adding more filters or using group_by")
 else:
     # Safe to paginate through results
     for i, work in enumerate(query.paginate(cursor="*"), 1):
         process(work)
-        if i >= 12000:
+        if i >= 1000:
             break
 ```

--- a/docs/works/get-a-single-work.md
+++ b/docs/works/get-a-single-work.md
@@ -71,7 +71,7 @@ Available external IDs for works are:
 | PubMed ID (PMID)               | `pmid`  |
 | PubMed Central ID (PMCID)      | `pmcid` |
 
-\u26a0\ufe0f You must make sure that the ID(s) you supply are valid and correct. If an ID you request is incorrect, you will get no result.
+Note: You must make sure that the ID(s) you supply are valid and correct. If an ID you request is incorrect, you will get no result.
 
 ## Select fields
 


### PR DESCRIPTION
## Summary
- reduce loop iterations in documentation examples
- drop emojis and remove comment noise
- keep API usage illustrative without large-scale calls

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850124103bc832b9474a14c84b25e2e