### PR TITLE
Add validation utilities for safer entity access

### DIFF
--- a/openalex/config.py
+++ b/openalex/config.py
@@ -47,6 +47,14 @@ class OpenAlexConfig(BaseModel):
         le=300,
         description="Request timeout in seconds",
     )
+    operation_timeouts: dict[str, float] = Field(
+        default_factory=lambda: {
+            "get": 10.0,
+            "list": 30.0,
+            "search": 20.0,
+            "autocomplete": 5.0,
+        }
+    )
     per_page: int = Field(
         default=DEFAULT_PER_PAGE,
         ge=1,

--- a/openalex/entities.py
+++ b/openalex/entities.py
@@ -65,6 +65,7 @@ from .models import (
 from .query import Query
 from .utils import Paginator, strip_id_prefix
 from .utils.params import normalize_params
+from .utils.validation import validate_entity_id
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import OpenAlexConfig
@@ -184,6 +185,7 @@ class BaseEntity(Generic[T, F]):
         params: dict[str, Any] | None = None,
     ) -> T:
         cache_manager = get_cache_manager(self._config)
+        entity_id = validate_entity_id(entity_id, self.endpoint.rstrip("s"))
         entity_id = strip_id_prefix(entity_id)
 
         def fetch() -> dict[str, Any]:

--- a/openalex/utils/__init__.py
+++ b/openalex/utils/__init__.py
@@ -53,6 +53,7 @@ from .text import (
     normalize_author_name,
     truncate_abstract,
 )
+from .validation import validate_entity_id
 
 __all__ = [
     "DOI_URL_PREFIX",
@@ -97,6 +98,7 @@ __all__ = [
     "retry_with_rate_limit",
     "strip_id_prefix",
     "truncate_abstract",
+    "validate_entity_id",
     "validate_id_format",
     "with_retry",
 ]

--- a/openalex/utils/params.py
+++ b/openalex/utils/params.py
@@ -35,7 +35,32 @@ __all__ = [
     "normalize_params",
     "serialize_filter_value",
     "serialize_params",
+    "validate_date_param",
+    "validate_numeric_param",
 ]
+
+
+def validate_date_param(value: str) -> str:
+    """Validate date format matches ISO 8601."""
+    from datetime import datetime
+
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - defensive
+        message = f"Invalid date format: {value}"
+        raise ValueError(message) from exc
+    return value
+
+
+def validate_numeric_param(value: int | float, min_val: int = 0, max_val: int = 1_000_000) -> int | float:
+    """Ensure numeric parameters are within reasonable ranges."""
+    if not isinstance(value, int | float):
+        message = f"Numeric value required, got {type(value).__name__}"
+        raise TypeError(message)
+    if value < min_val or value > max_val:
+        message = f"Value {value} outside allowed range [{min_val}, {max_val}]"
+        raise ValueError(message)
+    return value
 
 
 def serialize_filter_value(value: Any) -> str:

--- a/openalex/utils/validation.py
+++ b/openalex/utils/validation.py
@@ -1,0 +1,46 @@
+import re
+from urllib.parse import urlparse
+
+VALID_ENTITY_ID_PATTERN = re.compile(r"^[A-Z]\d{1,15}$")
+VALID_OPENALEX_URL_PATTERN = re.compile(r"^https://openalex\.org/[A-Z]\d{1,15}$")
+VALID_KEYWORD_URL_PATTERN = re.compile(r"^https://openalex\.org/keywords/[A-Za-z0-9-]+$")
+
+
+def validate_entity_id(entity_id: str, entity_type: str) -> str:
+    """Validate and sanitize entity IDs."""
+    # Strip whitespace
+    entity_id = entity_id.strip()
+
+    # Check if it's a URL
+    if entity_id.startswith("http"):
+        parsed = urlparse(entity_id)
+        if entity_type.lower() == "keyword":
+            if not VALID_KEYWORD_URL_PATTERN.match(entity_id):
+                message = f"Invalid OpenAlex URL: {entity_id}"
+                raise ValueError(message)
+            entity_id = parsed.path.split("/")[-1]
+        else:
+            if not VALID_OPENALEX_URL_PATTERN.match(entity_id):
+                message = f"Invalid OpenAlex URL: {entity_id}"
+                raise ValueError(message)
+            entity_id = parsed.path.split("/")[-1]
+
+    if entity_type.lower() == "keyword":
+        if entity_id.startswith("keywords/"):
+            entity_id = entity_id.split("/", 1)[1]
+        if not entity_id or "/" in entity_id:
+            message = f"Invalid keyword slug: {entity_id}"
+            raise ValueError(message)
+        return entity_id
+
+    # Validate ID format
+    if not VALID_ENTITY_ID_PATTERN.match(entity_id):
+        message = f"Invalid entity ID format: {entity_id}"
+        raise ValueError(message)
+
+    expected_prefix = entity_type[0].upper()
+    if not entity_id.startswith(expected_prefix):
+        message = f"Entity ID {entity_id} does not match type {entity_type}"
+        raise ValueError(message)
+
+    return entity_id

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,23 @@
+import pytest
+from openalex.utils.validation import validate_entity_id
+
+
+class TestValidation:
+    def test_valid_entity_ids_pass(self):
+        """Test valid IDs pass validation."""
+        assert validate_entity_id("W1234567890", "work") == "W1234567890"
+
+    def test_invalid_ids_raise_error(self):
+        """Test invalid IDs raise ValueError."""
+        with pytest.raises(ValueError):
+            validate_entity_id("invalid-id", "work")
+
+    def test_sql_injection_blocked(self):
+        """Test SQL injection attempts are blocked."""
+        with pytest.raises(ValueError):
+            validate_entity_id("W123'; DROP TABLE works;--", "work")
+
+    def test_url_parsing_works(self):
+        """Test URL parsing extracts ID correctly."""
+        result = validate_entity_id("https://openalex.org/W1234567890", "work")
+        assert result == "W1234567890"


### PR DESCRIPTION
## Summary
- validate entity IDs and numeric/date params
- enforce keyword slug handling
- add operation-specific timeouts
- test new validation logic

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685040ec1464832b9c499bb66225b296