### PR TITLE
Add batch fetching support for sync and async entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Development guidelines for contributors in `AGENTS.md`
 - Behavior-driven test suite covering async, caching, config, pagination, etc.
 - Synchronous ``OpenAlexClient`` for simple API access
+- Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 
 ### Changed
 - Fixed caching logic to handle list queries and thread safety

--- a/openalex/async_entities.py
+++ b/openalex/async_entities.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TypeVar, cast
+
+from structlog import get_logger
+
+from .entities import AsyncBaseEntity as _AsyncBaseEntity
+from .models import BaseFilter
+from .utils.validation import validate_entity_id
+
+T = TypeVar("T")
+F = TypeVar("F", bound=BaseFilter)
+
+logger = get_logger(__name__)
+
+
+class AsyncBaseEntity(_AsyncBaseEntity[T, F]):
+    async def get_many(self, ids: list[str], max_concurrent: int = 10) -> list[T]:
+        """Fetch multiple entities efficiently using concurrent requests."""
+        import asyncio
+
+        validated_ids: list[str] = []
+        for id in ids:
+            try:
+                validated_id = validate_entity_id(id, self.endpoint.rstrip("s"))
+                validated_ids.append(validated_id)
+            except ValueError as e:
+                logger.warning("Skipping invalid ID %s: %s", id, e)
+
+        semaphore = asyncio.Semaphore(max_concurrent)
+
+        async def fetch_with_semaphore(id: str) -> T | None:
+            async with semaphore:
+                try:
+                    return cast(T, await _AsyncBaseEntity.get(self, id))
+                except Exception:
+                    logger.exception("Failed to fetch %s", id)
+                    return None
+
+        results = await asyncio.gather(
+            *[fetch_with_semaphore(id) for id in validated_ids]
+        )
+        return [r for r in results if r is not None]

--- a/openalex/utils/__init__.py
+++ b/openalex/utils/__init__.py
@@ -7,6 +7,7 @@ from ..constants import (
     ORCID_URL_PREFIX,
     PMID_PREFIX,
 )
+from .batch import chunk_list
 from .common import (
     empty_list_result,
     ensure_prefix,
@@ -71,6 +72,7 @@ __all__ = [
     "SlidingWindowRateLimiter",
     "async_rate_limited",
     "async_with_retry",
+    "chunk_list",
     "clean_html",
     "clean_title",
     "constant_backoff",

--- a/openalex/utils/batch.py
+++ b/openalex/utils/batch.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Iterator
+
+__all__ = ["chunk_list"]
+
+
+def chunk_list(items: list[Any], chunk_size: int) -> Iterator[list[Any]]:
+    """Split list into chunks of specified size."""
+    for i in range(0, len(items), chunk_size):
+        yield items[i : i + chunk_size]

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -1,0 +1,72 @@
+import time
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+import pytest
+
+from openalex import AsyncWorks, Works
+from openalex.models import Work
+
+
+class TestBatchOperations:
+    def test_get_many_returns_all_valid_entities(self, mock_work_data):
+        works = Works()
+        ids = [f"W{i}" for i in range(2000000000, 2000000050)]
+
+        def side_effect(entity_id, params=None):
+            return Work(id=f"https://openalex.org/{entity_id}", display_name="x")
+
+        with patch.object(Works, "_get_single_entity", side_effect=side_effect):
+            results = works.get_many(ids)
+
+        assert len(results) == len(ids)
+        assert all(isinstance(w, Work) for w in results)
+
+    def test_invalid_ids_skipped_with_warning(self):
+        works = Works()
+        ids = ["W123", "invalid-id", "W456"]
+
+        def side_effect(entity_id, params=None):
+            return Work(id=f"https://openalex.org/{entity_id}", display_name=entity_id)
+
+        with patch.object(Works, "_get_single_entity", side_effect=side_effect), patch(
+            "openalex.entities.logger.warning"
+        ) as mock_warn:
+            results = works.get_many(ids)
+
+        assert len(results) == 2
+        mock_warn.assert_called_with(
+            "Skipping invalid ID %s: %s", "invalid-id", ANY
+        )
+
+    def test_concurrent_limit_respected(self):
+        works = Works()
+        ids = [f"W{i}" for i in range(4)]
+        call_times: list[float] = []
+
+        def side_effect(entity_id, params=None):
+            call_times.append(time.time())
+            time.sleep(0.1)
+            return Work(id=f"https://openalex.org/{entity_id}", display_name="x")
+
+        with patch.object(Works, "_get_single_entity", side_effect=side_effect):
+            start = time.time()
+            works.get_many(ids, max_concurrent=2)
+            duration = time.time() - start
+
+        assert len(call_times) == len(ids)
+        assert duration < 0.3
+        assert duration > 0.19
+
+    @pytest.mark.asyncio
+    async def test_async_version_works(self):
+        works = AsyncWorks()
+        ids = [f"W{i}" for i in range(2000000000, 2000000010)]
+
+        async def async_side_effect(entity_id):
+            return Work(id=f"https://openalex.org/{entity_id}", display_name="x")
+
+        with patch.object(AsyncWorks, "get", new=AsyncMock(side_effect=async_side_effect)):
+            results = await works.get_many(ids)
+
+        assert len(results) == len(ids)
+        assert all(isinstance(w, Work) for w in results)


### PR DESCRIPTION
## Summary
- implement `BaseEntity.get_many` for concurrent batch operations
- add async `get_many` method in `AsyncBaseEntity`
- provide `chunk_list` helper
- test new batch operations
- document new feature in changelog

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685050979c94832bb3b16d149b898efe