### PR TITLE
Add streaming paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronous ``OpenAlexClient`` for simple API access
 - Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 - Cache warming utility to pre-populate frequently accessed items
+- Streaming paginator for memory-efficient iteration
 
 ### Changed
 - Fixed caching logic to handle list queries and thread safety

--- a/docs/performance-guide.md
+++ b/docs/performance-guide.md
@@ -44,6 +44,18 @@ for page in query.paginate(per_page=200):  # Max allowed
 print(f"Completed processing {processed} works")
 ```
 
+## Stream Results
+
+```python
+# Iterate over results one item at a time
+from openalex import Works
+
+query = Works().filter(publication_year=2023)
+
+for work in query.stream(per_page=200, max_results=500):
+    print(work.id)
+```
+
 ## Select Fields
 
 ```python

--- a/openalex/streaming/__init__.py
+++ b/openalex/streaming/__init__.py
@@ -1,0 +1,3 @@
+from .stream import AsyncStreamingPaginator, StreamingPaginator
+
+__all__ = ["AsyncStreamingPaginator", "StreamingPaginator"]

--- a/openalex/streaming/stream.py
+++ b/openalex/streaming/stream.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..models import ListResult
+
+T = TypeVar("T")
+
+
+class StreamingPaginator(Iterator[T]):
+    """Memory-efficient streaming paginator."""
+
+    def __init__(
+        self,
+        fetch_func: Callable[[dict[str, Any]], ListResult[T]],
+        params: dict[str, Any],
+        per_page: int = 200,
+        max_results: int | None = None,
+    ) -> None:
+        self._fetch_func = fetch_func
+        self._params = params.copy()
+        self._per_page = per_page
+        self._max_results = max_results
+        self._cursor: str | None = "*"
+        self._current_page: ListResult[T] | None = None
+        self._current_index = 0
+        self._total_yielded = 0
+        self._exhausted = False
+
+    def __iter__(self) -> Iterator[T]:
+        return self
+
+    def __next__(self) -> T:
+        if self._exhausted:
+            raise StopIteration
+
+        if self._max_results is not None and self._total_yielded >= self._max_results:
+            self._exhausted = True
+            raise StopIteration
+
+        if self._current_page is None or self._current_index >= len(self._current_page.results):
+            self._fetch_next_page()
+
+        if self._current_page is None or not self._current_page.results:
+            self._exhausted = True
+            raise StopIteration
+
+        result = self._current_page.results[self._current_index]
+        self._current_index += 1
+        self._total_yielded += 1
+        return result
+
+    def _fetch_next_page(self) -> None:
+        if self._cursor is None:
+            self._exhausted = True
+            return
+
+        params = {
+            **self._params,
+            "per_page": self._per_page,
+            "cursor": self._cursor,
+        }
+
+        self._current_page = self._fetch_func(params)
+        self._current_index = 0
+        self._cursor = self._current_page.meta.next_cursor
+
+
+class AsyncStreamingPaginator(AsyncIterator[T]):
+    """Async memory-efficient streaming paginator."""
+
+    def __init__(
+        self,
+        fetch_func: Callable[[dict[str, Any]], Awaitable[ListResult[T]]],
+        params: dict[str, Any],
+        per_page: int = 200,
+        max_results: int | None = None,
+    ) -> None:
+        self._fetch_func = fetch_func
+        self._params = params.copy()
+        self._per_page = per_page
+        self._max_results = max_results
+        self._cursor: str | None = "*"
+        self._current_page: ListResult[T] | None = None
+        self._current_index = 0
+        self._total_yielded = 0
+        self._exhausted = False
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        return self
+
+    async def __anext__(self) -> T:
+        if self._exhausted:
+            raise StopAsyncIteration
+
+        if self._max_results is not None and self._total_yielded >= self._max_results:
+            self._exhausted = True
+            raise StopAsyncIteration
+
+        if self._current_page is None or self._current_index >= len(self._current_page.results):
+            await self._fetch_next_page()
+
+        if self._current_page is None or not self._current_page.results:
+            self._exhausted = True
+            raise StopAsyncIteration
+
+        result = self._current_page.results[self._current_index]
+        self._current_index += 1
+        self._total_yielded += 1
+        return result
+
+    async def _fetch_next_page(self) -> None:
+        if self._cursor is None:
+            self._exhausted = True
+            return
+
+        params = {
+            **self._params,
+            "per_page": self._per_page,
+            "cursor": self._cursor,
+        }
+
+        self._current_page = await self._fetch_func(params)
+        self._current_index = 0
+        self._cursor = self._current_page.meta.next_cursor

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,120 @@
+import tracemalloc
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from openalex import AsyncWorks, Works
+
+
+class TestStreaming:
+    def test_streaming_yields_individual_items(self):
+        works = Works()
+        page1 = {
+            "results": [
+                {"id": "https://openalex.org/W1", "display_name": "W1"},
+                {"id": "https://openalex.org/W2", "display_name": "W2"},
+            ],
+            "meta": {"count": 3, "page": 1, "per_page": 2, "next_cursor": "c2"},
+        }
+        page2 = {
+            "results": [
+                {"id": "https://openalex.org/W3", "display_name": "W3"}
+            ],
+            "meta": {"count": 3, "page": 2, "per_page": 1, "next_cursor": None},
+        }
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = [
+                Mock(status_code=200, json=Mock(return_value=page1)),
+                Mock(status_code=200, json=Mock(return_value=page2)),
+            ]
+            query = works.filter(publication_year=2023)
+            results = list(query.stream(per_page=2, max_results=3))
+
+        assert len(results) == 3
+        assert results[0].id.endswith("W1")
+        assert results[2].id.endswith("W3")
+
+    def test_memory_efficient_large_results(self):
+        works = Works()
+        responses = []
+        for i in range(5):
+            page = {
+                "results": [
+                    {"id": f"https://openalex.org/W{i}", "display_name": f"W{i}"}
+                ],
+                "meta": {
+                    "count": 5,
+                    "page": i + 1,
+                    "per_page": 1,
+                    "next_cursor": "c" if i < 4 else None,
+                },
+            }
+            responses.append(Mock(status_code=200, json=Mock(return_value=page)))
+
+        with patch("httpx.Client.request", side_effect=responses):
+            tracemalloc.start()
+            count = 0
+            for _ in works.filter(year=2023).stream(per_page=1, max_results=5):
+                count += 1
+                current, _ = tracemalloc.get_traced_memory()
+                assert current < 5 * 1024 * 1024
+            tracemalloc.stop()
+
+        assert count == 5
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_works(self):
+        works = AsyncWorks()
+
+        async def async_response(*args, **kwargs):
+            cursor = kwargs["params"].get("cursor", "*")
+            if cursor == "*":
+                return Mock(
+                    status_code=200,
+                    json=Mock(
+                        return_value={
+                            "results": [
+                                {
+                                    "id": "https://openalex.org/W1",
+                                    "display_name": "W1",
+                                }
+                            ],
+                            "meta": {
+                                "count": 2,
+                                "page": 1,
+                                "per_page": 1,
+                                "next_cursor": "c2",
+                            },
+                        }
+                    ),
+                )
+            return Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "results": [
+                            {
+                                "id": "https://openalex.org/W2",
+                                "display_name": "W2",
+                            }
+                        ],
+                        "meta": {
+                            "count": 2,
+                            "page": 2,
+                            "per_page": 1,
+                            "next_cursor": None,
+                        },
+                    }
+                ),
+            )
+
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
+            mock_request.side_effect = async_response
+            query = works.filter(publication_year=2023)
+            paginator = await query.stream(per_page=1, max_results=2)
+            count = 0
+            async for work in paginator:
+                count += 1
+                assert work.id
+
+        assert count == 2


### PR DESCRIPTION
## Summary
- add streaming paginator classes
- extend Query and AsyncQuery with stream methods
- document streaming usage in performance guide
- add unit tests for new streaming behavior

## Testing
- `pip install --no-cache-dir -r requirements-dev.txt`
- `ruff check .`
- `mypy openalex`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c5cb250832bada1bceb0bc177b6