### PR TITLE
Add integration tests with mocked API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5757,3 +5757,18 @@ def sample_search_params():
         "sample": 100,
         "seed": 42,
     }
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_state():
+    """Ensure cache and connection state do not leak between tests."""
+    from openalex.cache.manager import clear_cache, _cache_managers
+    from openalex.api import _connection_pool
+
+    clear_cache()
+    _cache_managers.clear()
+    _connection_pool.clear()
+    yield
+    clear_cache()
+    _cache_managers.clear()
+    _connection_pool.clear()

--- a/tests/fixtures/api_responses.py
+++ b/tests/fixtures/api_responses.py
@@ -1,0 +1,241 @@
+"""Fixtures for mocked API responses."""
+
+from datetime import datetime, timedelta
+from typing import Any
+
+
+class APIResponseFixtures:
+    """Container for API response fixtures."""
+
+    @staticmethod
+    def work_response(work_id: str = "W2755950973") -> dict[str, Any]:
+        """Create a realistic work response."""
+        return {
+            "id": f"https://openalex.org/{work_id}",
+            "doi": "https://doi.org/10.1103/physrevlett.118.091101",
+            "display_name": (
+                "GW170104: Observation of a 50-Solar-Mass Binary Black Hole Coalescence at Redshift 0.2"
+            ),
+            "publication_year": 2017,
+            "publication_date": "2017-06-01",
+            "type": "article",
+            "cited_by_count": 850,
+            "is_retracted": False,
+            "is_paratext": False,
+            "open_access": {
+                "is_oa": True,
+                "oa_status": "gold",
+                "oa_url": (
+                    "https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.118.221101"
+                ),
+                "any_repository_has_fulltext": True,
+            },
+            "authorships": [
+                {
+                    "author_position": "first",
+                    "author": {
+                        "id": "https://openalex.org/A2150889177",
+                        "display_name": "B. P. Abbott",
+                        "orcid": None,
+                    },
+                    "institutions": [
+                        {
+                            "id": "https://openalex.org/I157725225",
+                            "display_name": "California Institute of Technology",
+                            "ror": "https://ror.org/05dxps055",
+                            "country_code": "US",
+                            "type": "education",
+                        }
+                    ],
+                    "raw_affiliation_strings": [
+                        "LIGO, California Institute of Technology, Pasadena, CA 91125, USA"
+                    ],
+                }
+            ],
+            "locations": [
+                {
+                    "is_primary": True,
+                    "source": {
+                        "id": "https://openalex.org/S16175027",
+                        "display_name": "Physical Review Letters",
+                        "issn_l": "0031-9007",
+                        "is_oa": False,
+                        "is_in_doaj": False,
+                    },
+                }
+            ],
+            "primary_location": {
+                "is_primary": True,
+                "source": {
+                    "id": "https://openalex.org/S16175027",
+                    "display_name": "Physical Review Letters",
+                    "issn_l": "0031-9007",
+                    "is_oa": False,
+                    "is_in_doaj": False,
+                },
+            },
+            "referenced_works": [
+                "https://openalex.org/W2126385722",
+                "https://openalex.org/W2170499123",
+            ],
+            "referenced_works_count": 95,
+            "related_works": [
+                "https://openalex.org/W2755951606",
+                "https://openalex.org/W2736953509",
+            ],
+            "counts_by_year": [
+                {"year": 2023, "cited_by_count": 125},
+                {"year": 2022, "cited_by_count": 143},
+                {"year": 2021, "cited_by_count": 156},
+            ],
+            "updated_date": "2023-08-01T00:00:00",
+        }
+
+    @staticmethod
+    def author_response(author_id: str = "A2150889177") -> dict[str, Any]:
+        """Create a realistic author response."""
+        return {
+            "id": f"https://openalex.org/{author_id}",
+            "orcid": "https://orcid.org/0000-0002-3666-1234",
+            "display_name": "B. P. Abbott",
+            "display_name_alternatives": [
+                "Barry P. Abbott",
+                "B.P. Abbott",
+                "Abbott, B.P.",
+            ],
+            "works_count": 523,
+            "cited_by_count": 28451,
+            "last_known_institution": {
+                "id": "https://openalex.org/I157725225",
+                "display_name": "California Institute of Technology",
+                "ror": "https://ror.org/05dxps055",
+                "country_code": "US",
+                "type": "education",
+            },
+            "counts_by_year": [
+                {"year": 2023, "works_count": 15, "cited_by_count": 2150},
+                {"year": 2022, "works_count": 18, "cited_by_count": 2543},
+            ],
+            "updated_date": "2023-08-01T00:00:00",
+        }
+
+    @staticmethod
+    def search_response(query: str, page: int = 1, per_page: int = 25) -> dict[str, Any]:
+        """Create a search response with pagination."""
+        total_results = 150  # Simulate 150 total results
+        results = []
+        start_idx = (page - 1) * per_page
+        end_idx = min(start_idx + per_page, total_results)
+
+        for i in range(start_idx, end_idx):
+            results.append(
+                {
+                    "id": f"https://openalex.org/W{1000000 + i}",
+                    "display_name": f"Result {i + 1} for query: {query}",
+                    "publication_year": 2020 + (i % 4),
+                    "cited_by_count": 100 - i,
+                    "type": "article" if i % 3 != 0 else "preprint",
+                }
+            )
+
+        return {
+            "meta": {
+                "count": total_results,
+                "db_response_time_ms": 42,
+                "page": page,
+                "per_page": per_page,
+            },
+            "results": results,
+            "group_by": [],
+        }
+
+    @staticmethod
+    def group_by_response(field: str) -> dict[str, Any]:
+        """Create a group-by response."""
+        groups: list[dict[str, Any]] = []
+
+        if field == "publication_year":
+            for year in range(2020, 2024):
+                groups.append(
+                    {
+                        "key": str(year),
+                        "key_display_name": str(year),
+                        "count": 1000 - (year - 2020) * 100,
+                    }
+                )
+        elif field == "open_access.is_oa":
+            groups = [
+                {
+                    "key": "true",
+                    "key_display_name": "Open Access",
+                    "count": 6543,
+                },
+                {
+                    "key": "false",
+                    "key_display_name": "Closed Access",
+                    "count": 3457,
+                },
+            ]
+        elif field == "type":
+            groups = [
+                {
+                    "key": "article",
+                    "key_display_name": "Article",
+                    "count": 7500,
+                },
+                {
+                    "key": "preprint",
+                    "key_display_name": "Preprint",
+                    "count": 1500,
+                },
+                {
+                    "key": "book",
+                    "key_display_name": "Book",
+                    "count": 1000,
+                },
+            ]
+
+        return {
+            "meta": {
+                "count": sum(g["count"] for g in groups),
+                "db_response_time_ms": 35,
+                "page": 1,
+                "per_page": 200,
+            },
+            "results": [],
+            "group_by": groups,
+        }
+
+    @staticmethod
+    def error_response(status_code: int, error_type: str = "Bad Request") -> dict[str, Any]:
+        """Create an error response."""
+        messages = {
+            400: "Invalid filter parameter",
+            401: "Invalid API key",
+            403: "Access forbidden",
+            404: "Entity not found",
+            429: "Rate limit exceeded",
+            500: "Internal server error",
+            503: "Service temporarily unavailable",
+        }
+
+        return {
+            "error": error_type,
+            "message": messages.get(status_code, "Unknown error"),
+            "status_code": status_code,
+        }
+
+    @staticmethod
+    def rate_limit_headers(remaining: int = 0, reset_time: int | None = None) -> dict[str, str]:
+        """Create rate limit headers."""
+        if reset_time is None:
+            reset_time = int((datetime.now() + timedelta(seconds=60)).timestamp())
+
+        headers: dict[str, str] = {
+            "X-RateLimit-Limit": "100",
+            "X-RateLimit-Remaining": str(remaining),
+            "X-RateLimit-Reset": str(reset_time),
+        }
+        if remaining == 0:
+            headers["Retry-After"] = "60"
+        return headers

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from openalex.cache.manager import clear_cache, _cache_managers
+from openalex.api import _connection_pool
+
+
+@pytest.fixture(autouse=True)
+def reset_openalex_state():
+    """Reset shared caches and connection pools around each test."""
+    clear_cache()
+    _cache_managers.clear()
+    # replace with new dict to avoid id reuse issues
+    import openalex.cache.manager as manager_module
+
+    manager_module._cache_managers = {}
+    _connection_pool.clear()
+    yield
+    clear_cache()
+    _cache_managers.clear()
+    manager_module._cache_managers = {}
+    _connection_pool.clear()

--- a/tests/integration/test_cache_performance.py
+++ b/tests/integration/test_cache_performance.py
@@ -1,0 +1,196 @@
+"""Test cache performance and effectiveness."""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock, patch
+
+import pytest
+
+from openalex import Works
+from openalex.cache.memory import MemoryCache
+from openalex.cache.manager import CacheManager
+from openalex.config import OpenAlexConfig
+from tests.fixtures.api_responses import APIResponseFixtures
+
+
+class TestCachePerformance:
+    """Test cache performance in integration scenarios."""
+
+    @pytest.fixture
+    def fixtures(self):
+        return APIResponseFixtures()
+
+    @pytest.fixture
+    def cache(self):
+        """Create a fresh cache instance."""
+        return MemoryCache(max_size=100)
+
+    def _patched_manager(self, cache: MemoryCache) -> CacheManager:
+        manager = CacheManager(OpenAlexConfig(cache_enabled=True))
+        manager._cache = cache
+        return manager
+
+    def test_cache_hit_performance(self, fixtures, cache):
+        """Test performance improvement from cache hits."""
+        work_response = fixtures.work_response()
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.cache.manager.get_cache_manager",
+                return_value=self._patched_manager(cache),
+            ),
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=self._patched_manager(cache),
+            ),
+        ):
+            mock_request.return_value = Mock(
+                json=lambda: work_response, status_code=200
+            )
+            start = time.time()
+            work1 = Works()["W2755950973"]
+            first_time = time.time() - start
+
+            start = time.time()
+            work2 = Works()["W2755950973"]
+            second_time = time.time() - start
+
+            assert second_time < first_time
+            assert mock_request.call_count == 1
+
+            stats = cache.stats()
+            assert stats["hits"] >= 1
+            assert stats["misses"] >= 1
+
+    def test_cache_with_filters(self, fixtures, cache):
+        """Test cache works correctly with different filter combinations."""
+        search_response1 = fixtures.search_response("AI", page=1)
+        search_response2 = fixtures.search_response("ML", page=1)
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.cache.manager.get_cache_manager",
+                return_value=self._patched_manager(cache),
+            ),
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=self._patched_manager(cache),
+            ),
+        ):
+            mock_request.side_effect = [
+                Mock(json=lambda: search_response1, status_code=200),
+                Mock(json=lambda: search_response2, status_code=200),
+                Mock(json=lambda: search_response1, status_code=200),
+            ]
+            results1 = Works().search("AI").filter(publication_year=2023).get()
+            results2 = Works().search("ML").filter(publication_year=2023).get()
+            results3 = Works().search("AI").filter(publication_year=2023).get()
+
+            assert (
+                results1.results[0].display_name
+                != results2.results[0].display_name
+            )
+            assert (
+                results1.results[0].display_name
+                == results3.results[0].display_name
+            )
+            assert mock_request.call_count == 2
+
+    def test_cache_expiration(self, fixtures, cache):
+        """Test cache respects TTL."""
+        work_response = fixtures.work_response()
+        short_ttl_cache = MemoryCache()
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.cache.manager.get_cache_manager",
+                return_value=self._patched_manager(short_ttl_cache),
+            ),
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=self._patched_manager(short_ttl_cache),
+            ),
+        ):
+            mock_request.return_value = Mock(
+                json=lambda: work_response, status_code=200
+            )
+            cache_key = "test_key"
+            short_ttl_cache.set(cache_key, work_response, ttl=0.1)
+
+            assert short_ttl_cache.get(cache_key) is not None
+            time.sleep(0.2)
+            assert short_ttl_cache.get(cache_key) is None
+
+    def test_cache_size_limits(self, fixtures):
+        """Test cache eviction when size limit reached."""
+        small_cache = MemoryCache(max_size=3)
+
+        responses = []
+        for i in range(5):
+            response = {
+                "id": f"W{i}",
+                "display_name": f"Work {i}",
+                "publication_year": 2020 + i,
+            }
+            responses.append(Mock(json=lambda r=response: r, status_code=200))
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.cache.manager.get_cache_manager",
+                return_value=self._patched_manager(small_cache),
+            ),
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=self._patched_manager(small_cache),
+            ),
+        ):
+            mock_request.side_effect = responses
+            for i in range(5):
+                Works()[f"W{i}"]
+
+            stats = small_cache.stats()
+            assert stats["size"] <= 3
+            assert stats["evictions"] >= 2
+
+    def test_concurrent_cache_access(self, fixtures, cache):
+        """Test cache thread safety under concurrent access."""
+        work_response = fixtures.work_response()
+
+        errors: list[Exception] = []
+        results: list[str] = []
+
+        def fetch_work(work_id: str) -> None:
+            try:
+                with (
+                    patch("httpx.Client.request") as mock_request,
+                    patch(
+                        "openalex.cache.manager.get_cache_manager",
+                        return_value=self._patched_manager(cache),
+                    ),
+                    patch(
+                        "openalex.entities.get_cache_manager",
+                        return_value=self._patched_manager(cache),
+                    ),
+                ):
+                    mock_request.return_value = Mock(
+                        json=lambda: work_response, status_code=200
+                    )
+                    work = Works()[work_id]
+                    results.append(work.id)
+            except Exception as e:  # pragma: no cover - defensive
+                errors.append(e)
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [
+                executor.submit(fetch_work, "W2755950973") for _ in range(20)
+            ]
+            for future in futures:
+                future.result()
+
+        assert len(errors) == 0
+        assert len(results) == 20
+        assert results.count("https://openalex.org/W2755950973") == 20

--- a/tests/integration/test_complex_queries.py
+++ b/tests/integration/test_complex_queries.py
@@ -1,0 +1,192 @@
+"""Integration tests for complex query scenarios."""
+
+import pytest
+from unittest.mock import Mock, patch
+import httpx
+from openalex import Works, Authors
+from openalex.exceptions import APIError
+from tests.fixtures.api_responses import APIResponseFixtures
+
+
+class TestComplexQueries:
+    """Test complex query scenarios with mocked API."""
+
+    @pytest.fixture
+    def fixtures(self):
+        """Get API response fixtures."""
+        return APIResponseFixtures()
+
+    def test_search_with_filters_and_pagination(self, fixtures):
+        """Test search with multiple filters and pagination."""
+        page1_response = fixtures.search_response(
+            "machine learning", page=1, per_page=50
+        )
+        page2_response = fixtures.search_response(
+            "machine learning", page=2, per_page=50
+        )
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = [
+                Mock(json=lambda: page1_response, status_code=200),
+                Mock(json=lambda: page2_response, status_code=200),
+            ]
+
+            paginator = (
+                Works()
+                .search("machine learning")
+                .filter(publication_year=2023)
+                .filter(open_access={"is_oa": True})
+                .filter(type="article")
+                .sort(cited_by_count="desc")
+                .paginate(per_page=50)
+            )
+
+            page1 = next(paginator)
+            assert page1.meta.count == 150
+            assert len(page1.results) == 50
+            assert page1.meta.page == 1
+
+            page2 = next(paginator)
+            assert page2.meta.page == 2
+            assert len(page2.results) == 50
+
+    def test_group_by_with_filters(self, fixtures):
+        """Test group-by queries with filters."""
+        group_response = fixtures.group_by_response("publication_year")
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.return_value = Mock(
+                json=lambda: group_response, status_code=200
+            )
+            results = (
+                Works()
+                .filter(institutions={"country_code": "US"})
+                .filter(is_open_access=True)
+                .group_by("publication_year")
+                .get()
+            )
+
+            assert len(results.groups) == 4
+            assert results.groups[-1].key == "2023"
+            assert sum(g.count for g in results.groups) == results.meta.count
+
+    def test_chained_entity_queries(self, fixtures):
+        """Test following relationships between entities."""
+        author_response = fixtures.author_response()
+        work_response = fixtures.work_response()
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = [
+                Mock(json=lambda: author_response, status_code=200),
+                Mock(
+                    json=lambda: {
+                        "results": [work_response],
+                        "meta": {"count": 1},
+                    },
+                    status_code=200,
+                ),
+            ]
+            author = Authors()["A2150889177"]
+            assert author.display_name == "B. P. Abbott"
+
+            author_works = (
+                Works()
+                .filter(author={"id": author.id})
+                .filter(publication_year=2023)
+                .get()
+            )
+            assert author_works.meta.count == 1
+
+    def test_retry_on_rate_limit(self, fixtures):
+        """Test retry logic on rate limit errors."""
+        error_response = fixtures.error_response(429)
+        success_response = fixtures.work_response()
+        headers = fixtures.rate_limit_headers(remaining=0, reset_time=1)
+
+        from openalex.cache.manager import CacheManager
+        from openalex.config import OpenAlexConfig
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=CacheManager(OpenAlexConfig()),
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            mock_request.side_effect = [
+                Mock(
+                    json=lambda: error_response,
+                    status_code=429,
+                    headers=headers,
+                ),
+                Mock(json=lambda: success_response, status_code=200),
+            ]
+
+            work = Works()["W2755950973"]
+            assert work.display_name is not None
+            assert mock_sleep.called
+            assert mock_request.call_count == 2
+
+    def test_error_handling_cascade(self, fixtures):
+        """Test various error scenarios."""
+        from openalex.exceptions import (
+            ValidationError,
+            NotFoundError,
+            ServerError,
+            TemporaryError,
+        )
+
+        test_cases = [
+            (400, ValidationError, "invalid filter"),
+            (404, NotFoundError, "not found"),
+            (500, ServerError, "server error"),
+            (503, ServerError, "unavailable"),
+        ]
+
+        for status_code, expected_error, expected_msg in test_cases:
+            error_response = fixtures.error_response(status_code)
+            with patch("httpx.Client.request") as mock_request:
+                mock_request.return_value = Mock(
+                    json=lambda er=error_response: er,
+                    status_code=status_code,
+                )
+                with pytest.raises(expected_error) as exc_info:
+                    Works()["W123456789"]
+
+            assert expected_msg in str(exc_info.value).lower()
+
+    def test_select_fields_performance(self, fixtures):
+        """Test that select reduces response size."""
+        full_response = fixtures.work_response()
+        minimal_response = {
+            "id": full_response["id"],
+            "display_name": full_response["display_name"],
+            "publication_year": full_response["publication_year"],
+        }
+
+        from openalex.cache.manager import CacheManager
+        from openalex.config import OpenAlexConfig
+
+        with (
+            patch("httpx.Client.request") as mock_request,
+            patch(
+                "openalex.entities.get_cache_manager",
+                return_value=CacheManager(OpenAlexConfig()),
+            ),
+        ):
+            mock_request.side_effect = [
+                Mock(json=lambda: full_response, status_code=200),
+                Mock(json=lambda: minimal_response, status_code=200),
+            ]
+            Works().select(
+                [
+                    "id",
+                    "display_name",
+                    "publication_year",
+                ]
+            ).get(per_page=1)
+
+            calls = mock_request.call_args_list
+            params = calls[0].kwargs.get("params", {})
+            assert params.get("select") == "id,display_name,publication_year"

--- a/tests/integration/test_pagination_edge_cases.py
+++ b/tests/integration/test_pagination_edge_cases.py
@@ -1,0 +1,155 @@
+"""Test pagination edge cases and cursor behavior."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from openalex import Works
+from tests.fixtures.api_responses import APIResponseFixtures
+
+
+class TestPaginationEdgeCases:
+    """Test pagination edge cases."""
+
+    @pytest.fixture
+    def fixtures(self):
+        return APIResponseFixtures()
+
+    def test_empty_results(self, fixtures):
+        """Test handling of empty result sets."""
+        empty_response = {
+            "meta": {"count": 0, "page": 1, "per_page": 25},
+            "results": [],
+            "group_by": [],
+        }
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.return_value = Mock(
+                json=lambda: empty_response, status_code=200
+            )
+            paginator = (
+                Works().filter(title="nonexistent_paper_12345").paginate()
+            )
+            page1 = next(paginator)
+            assert page1.meta.count == 0
+            assert len(page1.results) == 0
+            with pytest.raises(StopIteration):
+                next(paginator)
+
+    def test_single_page_results(self, fixtures):
+        """Test results that fit in a single page."""
+        response = fixtures.search_response("test", page=1, per_page=200)
+        response["meta"]["count"] = 15
+        response["results"] = response["results"][:15]
+
+        empty_page = {
+            "meta": {"count": 15, "page": 2, "per_page": 200},
+            "results": [],
+            "group_by": [],
+        }
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = [
+                Mock(json=lambda: response, status_code=200),
+                Mock(json=lambda: empty_page, status_code=200),
+            ]
+            paginator = Works().search("test").paginate(per_page=200)
+            page1 = next(paginator)
+            assert page1.meta.count == 15
+            assert len(page1.results) == 15
+            page2 = next(paginator)
+            assert len(page2.results) == 0
+            with pytest.raises(StopIteration):
+                next(paginator)
+
+    def test_cursor_pagination(self, fixtures):
+        """Test cursor-based pagination."""
+        page1 = {
+            "meta": {
+                "count": 1000,
+                "page": 1,
+                "per_page": 100,
+                "next_cursor": "cursor_abc123",
+            },
+            "results": [
+                {"id": f"W{i}", "display_name": f"Work {i}"} for i in range(100)
+            ],
+        }
+        page2 = {
+            "meta": {
+                "count": 1000,
+                "page": 2,
+                "per_page": 100,
+                "next_cursor": "cursor_def456",
+            },
+            "results": [
+                {"id": f"W{i}", "display_name": f"Work {i}"}
+                for i in range(100, 200)
+            ],
+        }
+        page3 = {
+            "meta": {
+                "count": 1000,
+                "page": 10,
+                "per_page": 100,
+                "next_cursor": None,
+            },
+            "results": [
+                {"id": f"W{i}", "display_name": f"Work {i}"}
+                for i in range(900, 1000)
+            ],
+        }
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = [
+                Mock(json=lambda: page1, status_code=200),
+                Mock(json=lambda: page2, status_code=200),
+                Mock(json=lambda: page3, status_code=200),
+            ]
+            paginator = (
+                Works().filter(publication_year=2023).paginate(per_page=100)
+            )
+            first = next(paginator)
+            assert first.meta.next_cursor == "cursor_abc123"
+
+            second = next(paginator)
+            assert second.meta.next_cursor == "cursor_def456"
+
+            third = next(paginator)
+            assert third.meta.next_cursor is None
+            with pytest.raises(StopIteration):
+                next(paginator)
+
+    def test_paginate_max_results(self, fixtures):
+        """Test paginate() with max_results limit."""
+        responses = []
+        for i in range(5):
+            response = fixtures.search_response("test", page=i + 1, per_page=50)
+            response["meta"]["count"] = 500
+            responses.append(Mock(json=lambda r=response: r, status_code=200))
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = responses
+            paginator = (
+                Works().search("test").paginate(per_page=50, max_results=125)
+            )
+            all_results = list(paginator)
+
+            total_results = sum(len(page.results) for page in all_results)
+            assert total_results == 150
+            assert len(all_results) == 3
+            assert paginator.total_fetched == 125
+
+    def test_large_per_page_limit(self, fixtures):
+        """Test per_page limits."""
+        large_response = {
+            "meta": {"count": 500, "page": 1, "per_page": 200},
+            "results": [{"id": f"W{i}"} for i in range(200)],
+        }
+
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.return_value = Mock(
+                json=lambda: large_response, status_code=200
+            )
+            results = Works().get(per_page=1000)
+            assert results.meta.per_page == 200


### PR DESCRIPTION
## Summary
- add fixtures for mocked API responses
- add complex query integration tests
- cover pagination edge cases
- measure cache performance with memory cache
- fix tests and caching behavior

## Testing
- `python -m ruff check tests/integration/`
- `python -m ruff format tests/integration/`
- `python -m pytest tests/integration/ -v`
- `python -m pytest tests/fixtures/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6851b7297c0c832bbba5436c74b78ebd