### PR TITLE
Add performance monitoring

### DIFF
--- a/benchmarks/test_performance.py
+++ b/benchmarks/test_performance.py
@@ -1,0 +1,90 @@
+"""Performance benchmarks for OpenAlex client."""
+
+import pytest
+import time
+from unittest.mock import Mock, patch
+
+from openalex import Works, config
+from openalex.cache.memory import MemoryCache
+from tests.fixtures.api_responses import APIResponseFixtures
+
+
+class TestPerformanceBenchmarks:
+    """Performance benchmark tests."""
+
+    @pytest.fixture
+    def mock_fast_api(self):
+        """Mock API with consistent fast response times."""
+        fixtures = APIResponseFixtures()
+
+        def mock_get(*args, **kwargs):
+            time.sleep(0.05)
+            return Mock(
+                json=lambda: fixtures.work_response(),
+                status_code=200,
+            )
+
+        mock_client = Mock()
+        mock_client.get = mock_get
+        return mock_client
+
+    @pytest.mark.benchmark
+    def test_single_request_performance(self, mock_fast_api, benchmark):
+        """Benchmark single API request."""
+        with patch("openalex.client.http_client.get_client", return_value=mock_fast_api):
+            result = benchmark(lambda: Works()["W2755950973"])
+            assert result.id is not None
+
+    @pytest.mark.benchmark
+    def test_cache_performance(self, mock_fast_api, benchmark):
+        """Benchmark cache hit vs miss performance."""
+        cache = MemoryCache()
+
+        with patch("openalex.client.http_client.get_client", return_value=mock_fast_api):
+            with patch("openalex.config.get_cache", return_value=cache):
+                Works()["W2755950973"]
+
+                def cache_hit():
+                    return Works()["W2755950973"]
+
+                result = benchmark(cache_hit)
+                assert result.id is not None
+
+    @pytest.mark.benchmark
+    def test_filter_building_performance(self, benchmark):
+        """Benchmark query filter building."""
+
+        def build_complex_filter():
+            return (
+                Works()
+                .search("machine learning")
+                .filter(publication_year=2023)
+                .filter(is_open_access=True)
+                .filter(institutions={"country_code": "US"})
+                .filter(type="article")
+                .filter(has_doi=True)
+                .sort(cited_by_count="desc")
+                .select(["id", "display_name", "doi", "publication_year"])
+            )
+
+        query = benchmark(build_complex_filter)
+        assert query._search == "machine learning"
+        assert len(query._filters) >= 5
+
+    @pytest.mark.benchmark
+    def test_response_parsing_performance(self, benchmark):
+        """Benchmark response parsing performance."""
+        fixtures = APIResponseFixtures()
+        large_response = {
+            "meta": {"count": 1000, "page": 1, "per_page": 100},
+            "results": [fixtures.work_response() for _ in range(100)],
+        }
+
+        def parse_response():
+            from openalex.models import Work
+
+            return [Work(**item) for item in large_response["results"]]
+
+        results = benchmark(parse_response)
+        assert len(results) == 100
+        assert all(isinstance(w, Work) for w in results)

--- a/examples/performance_monitoring.py
+++ b/examples/performance_monitoring.py
@@ -1,0 +1,158 @@
+"""Example: Performance monitoring with OpenAlex client."""
+
+import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from openalex import Works, Authors, config
+from openalex.metrics import get_metrics, reset_metrics
+from openalex.logging import configure_logging
+
+
+def demo_performance_monitoring() -> None:
+    """Demonstrate performance monitoring capabilities."""
+    print("OpenAlex Performance Monitoring Demo")
+    print("=" * 50)
+
+    configure_logging(level="INFO", format="console")
+    reset_metrics()
+
+    config.max_retries = 3
+    config.retry_delay = 1.0
+
+    print("\n1. Making various API calls...")
+
+    work = Works()["W2755950973"]
+    print(f"   - Fetched work: {work.display_name[:50]}...")
+
+    results = (
+        Works()
+        .search("climate change")
+        .filter(publication_year=2023)
+        .filter(is_open_access=True)
+        .get(per_page=50)
+    )
+    print(f"   - Found {results.meta.count:,} works on climate change")
+
+    grouped = (
+        Works()
+        .filter(institutions={"country_code": "US"})
+        .group_by("type")
+        .get()
+    )
+    print(f"   - Grouped {len(grouped.groups)} work types")
+
+    print("\n2. Testing cache performance...")
+
+    start = time.time()
+    Authors()["A2150889177"]
+    first_time = time.time() - start
+
+    start = time.time()
+    Authors()["A2150889177"]
+    second_time = time.time() - start
+
+    print(f"   - First call: {first_time*1000:.2f}ms (cache miss)")
+    print(f"   - Second call: {second_time*1000:.2f}ms (cache hit)")
+    if second_time > 0:
+        print(f"   - Speedup: {first_time/second_time:.1f}x")
+
+    print("\n3. Performance Metrics Summary:")
+    print("-" * 50)
+
+    metrics = get_metrics()
+    report = metrics.to_dict()
+
+    print(f"Total Requests: {report['summary']['total_requests']}")
+    print(f"Success Rate: {report['summary']['success_rate']}")
+    print(f"Cache Hit Rate: {report['cache']['hit_rate']}")
+    print(f"Avg Response Time: {report['performance']['avg_response_time_ms']}ms")
+    print(f"95th Percentile: {report['performance']['p95_response_time_ms']}ms")
+
+    print("\nRequests by Endpoint:")
+    for endpoint, count in report['endpoints'].items():
+        print(f"  - {endpoint}: {count}")
+
+    if report['errors']:
+        print("\nErrors:")
+        for error_type, count in report['errors'].items():
+            print(f"  - {error_type}: {count}")
+
+
+def demo_concurrent_performance() -> None:
+    """Demonstrate performance under concurrent load."""
+    print("\n\nConcurrent Performance Test")
+    print("=" * 50)
+
+    reset_metrics()
+
+    def fetch_work(work_id: str) -> str:
+        work = Works()[work_id]
+        return work.display_name
+
+    work_ids = [
+        "W2755950973",
+        "W2126385722",
+        "W2170499123",
+        "W2755951606",
+        "W2736953509",
+    ]
+
+    print("Fetching 5 works concurrently...")
+
+    start = time.time()
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(fetch_work, wid) for wid in work_ids]
+        [f.result() for f in futures]
+    total_time = time.time() - start
+
+    print(f"\nCompleted in {total_time:.2f}s")
+    print(f"Average time per request: {total_time/len(work_ids):.2f}s")
+
+    metrics = get_metrics()
+    print(f"\nCache hit rate: {metrics.cache_hit_rate:.1%}")
+    print(f"Total retries: {metrics.total_retries}")
+
+
+async def demo_async_performance() -> None:
+    """Demonstrate async performance monitoring."""
+    print("\n\nAsync Performance Test")
+    print("=" * 50)
+
+    from openalex import AsyncWorks
+
+    reset_metrics()
+
+    async def fetch_works_async() -> list[Any]:
+        work_ids = [f"W{2755950973 + i}" for i in range(10)]
+        tasks = [AsyncWorks()[wid] for wid in work_ids]
+        return await asyncio.gather(*tasks, return_exceptions=True)
+
+    print("Fetching 10 works asynchronously...")
+    start = time.time()
+
+    results = await fetch_works_async()
+
+    total_time = time.time() - start
+    successful = sum(1 for r in results if not isinstance(r, Exception))
+
+    print(f"\nCompleted in {total_time:.2f}s")
+    print(f"Successful: {successful}/10")
+
+    metrics = get_metrics()
+    print(f"Average response time: {metrics.avg_response_time:.2f}ms")
+
+
+if __name__ == "__main__":
+    demo_performance_monitoring()
+    demo_concurrent_performance()
+    asyncio.run(demo_async_performance())
+
+    print("\n\nFinal Performance Summary")
+    print("=" * 50)
+    final_metrics = get_metrics()
+    print(f"Total API calls: {final_metrics.total_requests}")
+    print(f"Overall success rate: {final_metrics.success_rate:.1%}")
+    print(f"Overall cache hit rate: {final_metrics.cache_hit_rate:.1%}")
+    print(f"Session duration: {final_metrics.uptime.total_seconds():.1f}s")

--- a/openalex/__init__.py
+++ b/openalex/__init__.py
@@ -42,6 +42,8 @@ from .exceptions import (
     TimeoutError,
     ValidationError,
 )
+from .logging import configure_logging
+from .metrics import get_metrics, reset_metrics
 from .models import (
     Author,
     Concept,
@@ -97,10 +99,13 @@ __all__ = [
     "Works",
     "__version__",
     "close_all_async_connections",
+    "configure_logging",
+    "get_metrics",
     "gt_",
     "gte_",
     "lt_",
     "lte_",
     "not_",
     "or_",
+    "reset_metrics",
 ]

--- a/openalex/logging.py
+++ b/openalex/logging.py
@@ -1,0 +1,161 @@
+"""Logging configuration with privacy controls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from structlog.types import EventDict, Processor
+
+__all__ = [
+    "RequestLogger",
+    "configure_logging",
+    "sanitize_sensitive_data",
+]
+
+
+def sanitize_sensitive_data(data: Any) -> Any:
+    """Remove or mask sensitive data from logs."""
+    if isinstance(data, dict):
+        sanitized: dict[str, Any] = {}
+        sensitive_keys = {
+            "api_key",
+            "email",
+            "password",
+            "token",
+            "authorization",
+        }
+
+        for key, value in data.items():
+            if any(sensitive in key.lower() for sensitive in sensitive_keys):
+                sanitized[key] = "[REDACTED]"
+            else:
+                sanitized[key] = sanitize_sensitive_data(value)
+        return sanitized
+
+    if isinstance(data, list):
+        return [sanitize_sensitive_data(item) for item in data]
+
+    if isinstance(data, str):
+        import re
+
+        email_pattern = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+        return re.sub(email_pattern, "[EMAIL]", data)
+
+    return data
+
+
+class PrivacyProcessor:
+    """Structlog processor that sanitizes sensitive data."""
+
+    def __call__(
+        self, logger: Any, method_name: str, event_dict: EventDict
+    ) -> EventDict:
+        """Process log event to remove sensitive data."""
+        event_dict = sanitize_sensitive_data(event_dict)
+        return event_dict
+
+
+class RequestLogger:
+    """Logger for HTTP requests with privacy controls."""
+
+    def __init__(
+        self, enabled: bool = True, include_headers: bool = False
+    ) -> None:
+        """Initialize request logger."""
+        self.enabled = enabled
+        self.include_headers = include_headers
+        self.logger = structlog.get_logger(__name__)
+
+    def log_request(
+        self, method: str, url: str, headers: dict[str, str] | None = None
+    ) -> None:
+        """Log outgoing request."""
+        if not self.enabled:
+            return
+
+        log_data = {
+            "event": "http_request",
+            "method": method,
+            "url": self._sanitize_url(url),
+        }
+
+        if self.include_headers and headers:
+            log_data["headers"] = sanitize_sensitive_data(headers)
+
+        self.logger.info(**log_data)
+
+    def log_response(
+        self,
+        status_code: int,
+        response_time: float,
+        url: str,
+        cached: bool = False,
+    ) -> None:
+        """Log response received."""
+        if not self.enabled:
+            return
+
+        self.logger.info(
+            "http_response",
+            status_code=status_code,
+            response_time_ms=f"{response_time:.2f}",
+            url=self._sanitize_url(url),
+            cached=cached,
+        )
+
+    def log_error(self, error: Exception, url: str) -> None:
+        """Log request error."""
+        if not self.enabled:
+            return
+
+        self.logger.error(
+            "http_error",
+            error_type=type(error).__name__,
+            error_message=str(error),
+            url=self._sanitize_url(url),
+        )
+
+    def _sanitize_url(self, url: str) -> str:
+        """Remove sensitive parameters from URL."""
+        import re
+
+        return re.sub(r"api_key=[^&]+", "api_key=[REDACTED]", url)
+
+
+def configure_logging(
+    level: str = "INFO",
+    format: str = "json",
+    include_timestamps: bool = True,
+    privacy_mode: bool = True,
+) -> None:
+    """Configure structured logging for the OpenAlex client.
+
+    Args:
+        level: Log level (DEBUG, INFO, WARNING, ERROR)
+        format: Output format ('json' or 'console')
+        include_timestamps: Whether to include timestamps
+        privacy_mode: Whether to sanitize sensitive data
+    """
+    processors: list[Processor] = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+    ]
+
+    if include_timestamps:
+        processors.append(structlog.processors.TimeStamper(fmt="iso"))
+
+    if privacy_mode:
+        processors.append(PrivacyProcessor())
+
+    if format == "json":
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer())
+
+    structlog.configure(
+        processors=processors,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )

--- a/openalex/metrics/__init__.py
+++ b/openalex/metrics/__init__.py
@@ -1,4 +1,22 @@
+"""Metrics utilities and performance monitoring."""
+
 from .collector import MetricsCollector, MetricsReport
+from .performance import (
+    MetricType,
+    PerformanceMetrics,
+    get_collector,
+    get_metrics,
+    reset_metrics,
+)
 from .utils import get_metrics_collector
 
-__all__ = ["MetricsCollector", "MetricsReport", "get_metrics_collector"]
+__all__ = [
+    "MetricType",
+    "MetricsCollector",
+    "MetricsReport",
+    "PerformanceMetrics",
+    "get_collector",
+    "get_metrics",
+    "get_metrics_collector",
+    "reset_metrics",
+]

--- a/openalex/metrics/performance.py
+++ b/openalex/metrics/performance.py
@@ -1,0 +1,239 @@
+"""Performance metrics collection for OpenAlex client."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from threading import Lock
+from typing import Any
+
+from structlog import get_logger
+
+__all__ = [
+    "MetricType",
+    "MetricsCollector",
+    "PerformanceMetrics",
+    "get_collector",
+    "get_metrics",
+    "reset_metrics",
+]
+
+logger = get_logger(__name__)
+
+
+class MetricType(Enum):
+    """Types of metrics collected."""
+
+    API_CALL = "api_call"
+    CACHE_HIT = "cache_hit"
+    CACHE_MISS = "cache_miss"
+    RETRY = "retry"
+    ERROR = "error"
+    RATE_LIMIT = "rate_limit"
+
+
+@dataclass
+class PerformanceMetrics:
+    """Container for performance metrics."""
+
+    total_requests: int = 0
+    successful_requests: int = 0
+    failed_requests: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    total_retries: int = 0
+    rate_limit_hits: int = 0
+
+    response_times: list[float] = field(default_factory=list)
+    errors_by_type: dict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    requests_by_endpoint: dict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+
+    start_time: datetime = field(default_factory=datetime.now)
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Calculate cache hit rate."""
+        total_cache = self.cache_hits + self.cache_misses
+        return self.cache_hits / total_cache if total_cache > 0 else 0.0
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate request success rate."""
+        return (
+            self.successful_requests / self.total_requests
+            if self.total_requests > 0
+            else 0.0
+        )
+
+    @property
+    def avg_response_time(self) -> float:
+        """Calculate average response time in milliseconds."""
+        return (
+            sum(self.response_times) / len(self.response_times)
+            if self.response_times
+            else 0.0
+        )
+
+    @property
+    def p95_response_time(self) -> float:
+        """Calculate 95th percentile response time."""
+        if not self.response_times:
+            return 0.0
+        sorted_times = sorted(self.response_times)
+        index = int(len(sorted_times) * 0.95)
+        return (
+            sorted_times[index]
+            if index < len(sorted_times)
+            else sorted_times[-1]
+        )
+
+    @property
+    def uptime(self) -> timedelta:
+        """Get time since metrics collection started."""
+        return datetime.now() - self.start_time
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert metrics to dictionary for reporting."""
+        return {
+            "summary": {
+                "total_requests": self.total_requests,
+                "successful_requests": self.successful_requests,
+                "failed_requests": self.failed_requests,
+                "success_rate": f"{self.success_rate:.2%}",
+                "uptime_seconds": self.uptime.total_seconds(),
+            },
+            "cache": {
+                "hits": self.cache_hits,
+                "misses": self.cache_misses,
+                "hit_rate": f"{self.cache_hit_rate:.2%}",
+            },
+            "performance": {
+                "avg_response_time_ms": f"{self.avg_response_time:.2f}",
+                "p95_response_time_ms": f"{self.p95_response_time:.2f}",
+                "total_retries": self.total_retries,
+                "rate_limit_hits": self.rate_limit_hits,
+            },
+            "endpoints": dict(self.requests_by_endpoint),
+            "errors": dict(self.errors_by_type),
+        }
+
+
+class MetricsCollector:
+    """Thread-safe metrics collector."""
+
+    def __init__(self) -> None:
+        """Initialize metrics collector."""
+        self._metrics = PerformanceMetrics()
+        self._lock = Lock()
+        self._enabled = True
+
+    def record_request(
+        self, endpoint: str, response_time: float, success: bool
+    ) -> None:
+        """Record an API request."""
+        if not self._enabled:
+            return
+
+        with self._lock:
+            self._metrics.total_requests += 1
+            self._metrics.response_times.append(response_time)
+            self._metrics.requests_by_endpoint[endpoint] += 1
+
+            if success:
+                self._metrics.successful_requests += 1
+            else:
+                self._metrics.failed_requests += 1
+
+            if len(self._metrics.response_times) > 1000:
+                self._metrics.response_times = self._metrics.response_times[
+                    -1000:
+                ]
+
+    def record_cache_hit(self) -> None:
+        """Record a cache hit."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._metrics.cache_hits += 1
+
+    def record_cache_miss(self) -> None:
+        """Record a cache miss."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._metrics.cache_misses += 1
+
+    def record_retry(self) -> None:
+        """Record a retry attempt."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._metrics.total_retries += 1
+
+    def record_error(self, error_type: str) -> None:
+        """Record an error by type."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._metrics.errors_by_type[error_type] += 1
+
+    def record_rate_limit(self) -> None:
+        """Record a rate limit hit."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._metrics.rate_limit_hits += 1
+
+    def get_metrics(self) -> PerformanceMetrics:
+        """Get a copy of current metrics."""
+        with self._lock:
+            return PerformanceMetrics(
+                total_requests=self._metrics.total_requests,
+                successful_requests=self._metrics.successful_requests,
+                failed_requests=self._metrics.failed_requests,
+                cache_hits=self._metrics.cache_hits,
+                cache_misses=self._metrics.cache_misses,
+                total_retries=self._metrics.total_retries,
+                rate_limit_hits=self._metrics.rate_limit_hits,
+                response_times=self._metrics.response_times.copy(),
+                errors_by_type=dict(self._metrics.errors_by_type),
+                requests_by_endpoint=dict(self._metrics.requests_by_endpoint),
+                start_time=self._metrics.start_time,
+            )
+
+    def reset(self) -> None:
+        """Reset all metrics."""
+        with self._lock:
+            self._metrics = PerformanceMetrics()
+
+    def enable(self) -> None:
+        """Enable metrics collection."""
+        self._enabled = True
+
+    def disable(self) -> None:
+        """Disable metrics collection."""
+        self._enabled = False
+
+
+_metrics_collector = MetricsCollector()
+
+
+def get_metrics() -> PerformanceMetrics:
+    """Get current performance metrics."""
+    return _metrics_collector.get_metrics()
+
+
+def reset_metrics() -> None:
+    """Reset all performance metrics."""
+    _metrics_collector.reset()
+
+
+def get_collector() -> MetricsCollector:
+    """Get the global metrics collector instance."""
+    return _metrics_collector


### PR DESCRIPTION
## Summary
- implement performance metrics collector
- record cache and retry metrics
- add logging utilities with privacy sanitization
- expose metrics in `__init__`
- provide example and benchmark suite

## Testing
- `python -m ruff format openalex/`
- `python -m ruff check openalex/`
- `timeout 30s python -m mypy openalex/metrics/performance.py openalex/logging.py --ignore-missing-imports`
- `python -m pytest benchmarks/ -v --benchmark-only` *(failed: unrecognized arguments)*
- `python examples/performance_monitoring.py` *(failed: AuthenticationError)*
- `python -m pytest tests/ -v` *(failed: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6851bee4ce8c832bb1bceaf66f6edd30