### PR TITLE
Fix metrics collector shared-state bug

### DIFF
--- a/examples/performance_monitoring.py
+++ b/examples/performance_monitoring.py
@@ -5,9 +5,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from openalex import Works, Authors, config
-from openalex.metrics import get_metrics, reset_metrics
+from openalex import Authors, Works, config
 from openalex.logging import configure_logging
+from openalex.metrics import get_metrics, reset_metrics
 
 
 def demo_performance_monitoring() -> None:
@@ -71,12 +71,12 @@ def demo_performance_monitoring() -> None:
     print(f"95th Percentile: {report['performance']['p95_response_time_ms']}ms")
 
     print("\nRequests by Endpoint:")
-    for endpoint, count in report['endpoints'].items():
+    for endpoint, count in report["endpoints"].items():
         print(f"  - {endpoint}: {count}")
 
-    if report['errors']:
+    if report["errors"]:
         print("\nErrors:")
-        for error_type, count in report['errors'].items():
+        for error_type, count in report["errors"].items():
             print(f"  - {error_type}: {count}")
 
 

--- a/openalex/metrics/utils.py
+++ b/openalex/metrics/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from typing import TYPE_CHECKING
 
 from .collector import MetricsCollector
@@ -7,12 +8,19 @@ from .collector import MetricsCollector
 if TYPE_CHECKING:
     from ..config import OpenAlexConfig
 
-_metrics_collectors: dict[int, MetricsCollector] = {}
+_metrics_collectors: dict[int, tuple[weakref.ReferenceType[OpenAlexConfig], MetricsCollector]] = {}
 
 
 def get_metrics_collector(config: OpenAlexConfig) -> MetricsCollector:
     """Get or create metrics collector for config."""
     key = id(config)
-    if key not in _metrics_collectors:
-        _metrics_collectors[key] = MetricsCollector()
-    return _metrics_collectors[key]
+    entry = _metrics_collectors.get(key)
+    if entry is not None:
+        ref, collector = entry
+        if ref() is config:
+            return collector
+        if ref() is None:
+            del _metrics_collectors[key]
+    collector = MetricsCollector()
+    _metrics_collectors[key] = (weakref.ref(config), collector)
+    return collector


### PR DESCRIPTION
## Summary
- isolate metrics collectors and caches per config with weak references
- update imports in performance monitoring example

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/test_metrics.py::TestMetrics::test_metrics_collection_when_enabled tests/test_metrics.py::TestMetrics::test_cache_metrics_tracked tests/test_middleware.py::TestMiddleware::test_response_interceptor_transforms_data tests/test_resilience.py::TestResilience::test_circuit_breaker_opens_after_failures -vv`

------
https://chatgpt.com/codex/tasks/task_e_685227f9a524832ba617e46a01d57298