### PR TITLE
fix: clear metrics collectors in test fixture to prevent state leakage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5764,11 +5764,14 @@ def _reset_global_state():
     """Ensure cache and connection state do not leak between tests."""
     from openalex.cache.manager import clear_cache, _cache_managers
     from openalex.api import _connection_pool
+    from openalex.metrics.utils import _metrics_collectors
 
     clear_cache()
     _cache_managers.clear()
     _connection_pool.clear()
+    _metrics_collectors.clear()
     yield
     clear_cache()
     _cache_managers.clear()
     _connection_pool.clear()
+    _metrics_collectors.clear()


### PR DESCRIPTION
## Summary
- ensure `_reset_global_state` fixture clears metrics collectors

## Testing
- `ruff check .`
- `mypy openalex`
- `poetry run pytest tests/test_metrics.py tests/test_middleware.py tests/test_resilience.py`
- `poetry run pytest` *(fails: 4 failed, 451 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6852c7ae8078832b854cc8e6460d5af4