### PR TITLE
Add comprehensive async and logging tests

### DIFF
--- a/tests/behavior/test_async.py
+++ b/tests/behavior/test_async.py
@@ -395,3 +395,131 @@ class TestAsyncBehavior:
 
             # Verify cleanup was called (implementation dependent)
             # Main point is it doesn't raise an error
+
+    async def test_all_async_entity_types_work(self):
+        """Test that all async entity types can perform basic operations."""
+        from openalex import (
+            AsyncConcepts,
+            AsyncFunders,
+            AsyncKeywords,
+            AsyncPublishers,
+            AsyncTopics,
+        )
+
+        test_cases = [
+            (AsyncConcepts(), "C2778407487", "artificial intelligence"),
+            (AsyncFunders(), "F4320306076", "National Science Foundation"),
+            (AsyncKeywords(), "K123", "machine learning"),
+            (AsyncPublishers(), "P4310319965", "Elsevier"),
+            (AsyncTopics(), "T10001", "Climate change"),
+        ]
+
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
+            for entity, entity_id, expected_name in test_cases:
+                mock_request.return_value = Mock(
+                    status_code=200,
+                    json=Mock(
+                        return_value={
+                            "id": f"https://openalex.org/{entity_id}",
+                            "display_name": expected_name,
+                        }
+                    ),
+                )
+
+                result = await entity.get(entity_id)
+
+                assert result.display_name == expected_name
+                assert entity.endpoint in mock_request.call_args.kwargs["url"]
+                assert entity_id in mock_request.call_args.kwargs["url"]
+
+    async def test_async_ngrams_functionality(self):
+        """Test async Works.ngrams() method."""
+        from openalex import AsyncWorks
+
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "meta": {"count": 2},
+                        "results": [
+                            {
+                                "ngram": "climate change",
+                                "ngram_count": 5,
+                                "ngram_tokens": 2,
+                            },
+                            {
+                                "ngram": "global warming",
+                                "ngram_count": 3,
+                                "ngram_tokens": 2,
+                            },
+                        ],
+                    }
+                ),
+            )
+
+            works = AsyncWorks()
+            ngrams = await works.ngrams("W2741809807")
+
+            assert len(ngrams.results) == 2
+            assert ngrams.results[0].ngram == "climate change"
+
+    async def test_async_autocomplete_multiple_entities(self):
+        """Test async autocomplete functionality for multiple entity types."""
+        from openalex import AsyncWorks, AsyncAuthors
+
+        test_cases = [
+            (
+                AsyncWorks(),
+                "climate ch",
+                ["Climate change impacts", "Climate change mitigation"],
+            ),
+            (
+                AsyncAuthors(),
+                "einstein a",
+                ["Einstein, Albert", "Einstein, Alfred"],
+            ),
+        ]
+
+        for entity, query, expected_hints in test_cases:
+            with patch(
+                "httpx.AsyncClient.request", new_callable=AsyncMock
+            ) as mock_request:
+                mock_request.return_value = Mock(
+                    status_code=200,
+                    json=Mock(
+                        return_value={
+                            "results": [
+                                {"id": f"hint{i}", "display_name": hint}
+                                for i, hint in enumerate(expected_hints)
+                            ],
+                            "meta": {"count": len(expected_hints)},
+                        }
+                    ),
+                )
+
+                results = await entity.autocomplete(query)
+                assert len(results.results) == len(expected_hints)
+                assert results.results[0].display_name == expected_hints[0]
+
+    async def test_async_random_entity(self):
+        """Test async random entity fetching."""
+        from openalex import AsyncInstitutions
+
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "id": "https://openalex.org/I123",
+                        "display_name": "Random University",
+                    }
+                ),
+            )
+
+            institutions = AsyncInstitutions()
+            random_inst = await institutions.random()
+
+            assert random_inst.display_name == "Random University"
+            assert "/random" in mock_request.call_args.kwargs["url"]
+

--- a/tests/models/test_filter_models.py
+++ b/tests/models/test_filter_models.py
@@ -1,0 +1,104 @@
+"""Test filter models and parameter building."""
+
+import pytest
+from datetime import date, datetime
+
+from openalex.models.filters import BaseFilter
+
+
+class TestFilterModels:
+    """Test filter model functionality."""
+
+    def test_base_filter_validation(self):
+        """Test BaseFilter validation and defaults."""
+        filter_obj = BaseFilter(
+            search="machine learning",
+            filter={"publication_year": 2023},
+            sort="cited_by_count:desc",
+            page=2,
+            per_page=50,
+        )
+
+        assert filter_obj.search == "machine learning"
+        assert filter_obj.filter == {"publication_year": 2023}
+        assert filter_obj.page == 2
+        assert filter_obj.per_page == 50
+
+    def test_filter_string_format(self):
+        """Test filter string can be passed directly."""
+        filter_obj = BaseFilter(filter="publication_year:2023,is_oa:true")
+        assert filter_obj.filter == "publication_year:2023,is_oa:true"
+
+    def test_select_field_validation(self):
+        """Test select field accepts string or list."""
+        f1 = BaseFilter(select="id,display_name")
+        assert f1.select == "id,display_name"
+
+        f2 = BaseFilter(select=["id", "display_name", "cited_by_count"])
+        assert f2.select == ["id", "display_name", "cited_by_count"]
+
+        with pytest.raises(ValueError, match="Select must be"):
+            BaseFilter(select=123)
+
+    def test_to_params_conversion(self):
+        """Test conversion to API parameters."""
+        filter_obj = BaseFilter(
+            filter={
+                "is_oa": True,
+                "publication_year": [2022, 2023],
+                "institutions.country_code": "US",
+                "from_publication_date": date(2023, 1, 1),
+            },
+            select=["id", "title"],
+            group_by="publication_year",
+            per_page=100,
+        )
+
+        params = filter_obj.to_params()
+
+        assert (
+            params["filter"]
+            == "is_oa:true,publication_year:2022|2023,institutions.country_code:US,from_publication_date:2023-01-01"
+        )
+        assert params["select"] == "id,title"
+        assert params["group-by"] == "publication_year"
+        assert params["per-page"] == 100
+
+    def test_complex_filter_building(self):
+        """Test complex filter scenarios."""
+        filter_obj = BaseFilter(
+            filter={
+                "authorships.author.id": ["A123", "A456"],
+                "has_doi": True,
+                "cited_by_count": ">100",
+                "concepts.id": ["C2778407487", "C41008148"],
+                "published_date": datetime(2023, 6, 15),
+            }
+        )
+
+        params = filter_obj.to_params()
+        filter_str = params["filter"]
+
+        assert "authorships.author.id:A123|A456" in filter_str
+        assert "has_doi:true" in filter_str
+        assert "cited_by_count:>100" in filter_str
+        assert "published_date:2023-06-15" in filter_str
+
+    def test_empty_filter_values_ignored(self):
+        """Test empty values are ignored in filters."""
+        filter_obj = BaseFilter(
+            filter={
+                "is_oa": True,
+                "empty_list": [],
+                "none_value": None,
+                "valid_list": ["A", "B"],
+            }
+        )
+
+        params = filter_obj.to_params()
+        filter_str = params["filter"]
+
+        assert "is_oa:true" in filter_str
+        assert "valid_list:A|B" in filter_str
+        assert "empty_list" not in filter_str
+        assert "none_value" not in filter_str

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -480,3 +480,24 @@ class TestWorkModel:
         assert "crossref" in work.indexed_in
         assert "doaj" in work.indexed_in
         assert "pubmed" in work.indexed_in
+
+    def test_work_convenience_methods(self, mock_work_data):
+        """Test Work model convenience methods."""
+        from openalex.models import Work
+
+        work = Work(**mock_work_data)
+
+        assert work.citations_in_year(2023) > 0
+        assert work.citations_in_year(1999) == 0
+
+        author_names = work.author_names()
+        assert any("Heather" in name for name in author_names)
+        assert any("Jason" in name for name in author_names)
+
+        inst_names = work.institution_names()
+        assert len(inst_names) > 0
+
+        assert work.has_references() is True
+
+        work_no_abstract = Work(**{**mock_work_data, "abstract": None, "abstract_inverted_index": None})
+        assert work_no_abstract.has_abstract() is False

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,4 +1,5 @@
 import time
+import asyncio
 from unittest.mock import Mock, patch
 
 import pytest
@@ -51,3 +52,70 @@ class TestResilience(IsolatedTestCase):
 
     def test_request_queue_during_rate_limit(self):
         pass
+
+    @pytest.mark.asyncio
+    async def test_async_circuit_breaker_lifecycle(self):
+        """Test async circuit breaker state transitions."""
+        from openalex.resilience import AsyncCircuitBreaker
+        from openalex.resilience.async_circuit_breaker import CircuitState
+        import asyncio
+
+        breaker = AsyncCircuitBreaker(
+            failure_threshold=2,
+            recovery_timeout=0.1,
+            expected_exception=ServerError,
+        )
+
+        assert await breaker.state() == CircuitState.CLOSED
+
+        async def failing_call():
+            raise ServerError("Service unavailable")
+
+        for _ in range(2):
+            with pytest.raises(ServerError):
+                await breaker.call(failing_call)
+
+        assert await breaker.state() == CircuitState.OPEN
+
+        with pytest.raises(RuntimeError, match="Circuit breaker is open"):
+            await breaker.call(failing_call)
+
+        await asyncio.sleep(0.2)
+        assert await breaker.state() == CircuitState.HALF_OPEN
+
+        async def success_call():
+            return "success"
+
+        result = await breaker.call(success_call)
+        assert result == "success"
+        assert await breaker.state() == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_async_request_queue(self):
+        """Test async request queue with rate limiting."""
+        from openalex.resilience import AsyncRequestQueue
+        from openalex.utils import AsyncRateLimiter
+
+        queue = AsyncRequestQueue(max_size=10)
+        rate_limiter = AsyncRateLimiter(rate=5)
+        queue.set_rate_limiter(rate_limiter)
+
+        queue.start()
+
+        try:
+            execution_times = []
+
+            async def timed_request():
+                start = time.time()
+                await asyncio.sleep(0.01)
+                execution_times.append(time.time())
+                return start
+
+            tasks = [queue.enqueue(timed_request) for _ in range(10)]
+            results = await asyncio.gather(*tasks)
+
+            total_time = max(execution_times) - min(execution_times)
+            assert total_time >= 0.5
+            assert len(results) == 10
+        finally:
+            await queue.stop()


### PR DESCRIPTION
## Summary
- expand async behavior tests for entities and ngrams
- test connection pool reuse and header building
- cover timeout handling and async connection lifecycle
- add new filter model tests
- exercise async circuit breaker and request queue
- verify logging configuration and sanitization
- extend Work model convenience method coverage
- fix async rate-limiter tests

## Testing
- `ruff check .`
- `mypy openalex`
- `pytest tests/behavior/test_exceptions.py::TestExceptionBehavior::test_connection_timeout_handling tests/utils/test_utils.py::TestLogging::test_configure_logging_json_format tests/utils/test_utils.py::TestLogging::test_sanitize_sensitive_data tests/utils/test_utils.py::TestLogging::test_request_logger tests/models/test_work.py::TestWorkModel::test_work_convenience_methods tests/behavior/test_async.py::TestAsyncBehavior::test_async_random_entity tests/test_resilience.py::TestResilience::test_async_request_queue -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ff1e3c00832bad64bebb7b470713