### PR TITLE
Add tests for Funder model

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 omit =
     openalex/connection.py
-    openalex/metrics/performance.py
     openalex/query.py
     openalex/entities.py
     openalex/models/work.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,5 +6,4 @@ omit =
     openalex/query.py
     openalex/entities.py
     openalex/models/work.py
-    openalex/models/source.py
     openalex/models/institution.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,3 @@ omit =
     openalex/query.py
     openalex/entities.py
     openalex/models/work.py
-    openalex/models/institution.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 omit =
     openalex/connection.py
     openalex/metrics/performance.py
-    openalex/utils/pagination.py
     openalex/query.py
     openalex/entities.py
     openalex/models/work.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,3 @@ omit =
     openalex/models/work.py
     openalex/models/source.py
     openalex/models/institution.py
-    openalex/models/funder.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Behavior-driven test suite covering async, caching, config, pagination, etc.
 - Synchronous ``OpenAlexClient`` for simple API access
 - Unexcluded ``Source`` model from coverage and added tests
+- Unexcluded ``Institution`` model from coverage and added tests
 - Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 - Cache warming utility to pre-populate frequently accessed items
 - Streaming paginator for memory-efficient iteration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronous ``OpenAlexClient`` for simple API access
 - Unexcluded ``Source`` model from coverage and added tests
 - Unexcluded ``Institution`` model from coverage and added tests
+- Unexcluded pagination utilities from coverage and added tests
 - Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 - Cache warming utility to pre-populate frequently accessed items
 - Streaming paginator for memory-efficient iteration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Development guidelines for contributors in `AGENTS.md`
 - Behavior-driven test suite covering async, caching, config, pagination, etc.
 - Synchronous ``OpenAlexClient`` for simple API access
+- Unexcluded ``Source`` model from coverage and added tests
 - Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 - Cache warming utility to pre-populate frequently accessed items
 - Streaming paginator for memory-efficient iteration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unexcluded ``Source`` model from coverage and added tests
 - Unexcluded ``Institution`` model from coverage and added tests
 - Unexcluded pagination utilities from coverage and added tests
+- Unexcluded metrics performance module from coverage and added tests
 - Batch fetching via ``BaseEntity.get_many`` and ``AsyncBaseEntity.get_many``
 - Cache warming utility to pre-populate frequently accessed items
 - Streaming paginator for memory-efficient iteration

--- a/tests/metrics/test_performance_extra.py
+++ b/tests/metrics/test_performance_extra.py
@@ -1,0 +1,58 @@
+import pytest
+
+from openalex.metrics.performance import (
+    get_collector,
+    get_metrics,
+    reset_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    reset_metrics()
+    yield
+    reset_metrics()
+
+
+def test_metrics_collector_records_and_resets() -> None:
+    collector = get_collector()
+    collector.record_request("works", 0.5, success=True)
+    collector.record_request("works", 0.2, success=False)
+    collector.record_cache_hit()
+    collector.record_cache_miss()
+    collector.record_retry()
+    collector.record_error("HTTPError")
+    collector.record_rate_limit()
+
+    metrics = get_metrics()
+    assert metrics.total_requests == 2
+    assert metrics.successful_requests == 1
+    assert metrics.failed_requests == 1
+    assert metrics.cache_hits == 1
+    assert metrics.cache_misses == 1
+    assert metrics.total_retries == 1
+    assert metrics.rate_limit_hits == 1
+    assert metrics.errors_by_type["HTTPError"] == 1
+    assert metrics.requests_by_endpoint["works"] == 2
+    assert pytest.approx(metrics.avg_response_time, rel=1e-3) == 0.35
+
+    report = metrics.to_dict()
+    assert report["summary"]["total_requests"] == 2
+
+    reset_metrics()
+    assert get_metrics().total_requests == 0
+
+
+def test_metrics_collector_disable_enable() -> None:
+    collector = get_collector()
+    collector.disable()
+    collector.record_request("works", 0.1, success=True)
+    collector.record_cache_hit()
+
+    metrics = get_metrics()
+    assert metrics.total_requests == 0
+    assert metrics.cache_hits == 0
+
+    collector.enable()
+    collector.record_request("works", 0.1, success=True)
+    assert get_metrics().total_requests == 1

--- a/tests/models/test_funder_extra.py
+++ b/tests/models/test_funder_extra.py
@@ -1,0 +1,60 @@
+from datetime import date
+
+import pytest
+
+from openalex.models import Funder, CountsByYear, SummaryStats
+
+
+def make_funder(**kwargs: object) -> Funder:
+    data = {
+        "id": "https://openalex.org/F1",
+        "display_name": "National Health Agency",
+        "grants_count": 0,
+        "works_count": 0,
+    }
+    data.update(kwargs)
+    return Funder(**data)  # type: ignore[arg-type]
+
+
+def test_parse_updated_date_allows_overflow_seconds() -> None:
+    funder = make_funder(updated_date="2020-01-02T00:00:61")
+    assert funder.updated_date == date(2020, 1, 2)
+
+
+def test_country_code_validation_and_normalization() -> None:
+    funder = make_funder(country_code="us")
+    assert funder.country_code == "US"
+    with pytest.raises(ValueError):
+        Funder(id="https://openalex.org/F2", display_name="X", country_code="USA")
+
+
+def test_is_government_funder_detection() -> None:
+    gov = make_funder(display_name="Federal Research Agency")
+    private = make_funder(display_name="Private Research Foundation")
+    assert gov.is_government_funder()
+    assert not private.is_government_funder()
+
+
+def test_funding_per_work_calculation() -> None:
+    funder = make_funder(grants_count=20, works_count=5)
+    assert funder.funding_per_work == 4
+    no_work = make_funder(grants_count=10, works_count=0)
+    assert no_work.funding_per_work is None
+
+
+def test_year_based_helpers() -> None:
+    counts = [
+        CountsByYear(year=2022, works_count=5, cited_by_count=10),
+        CountsByYear(year=2021, works_count=0, cited_by_count=2),
+    ]
+    funder = make_funder(counts_by_year=counts)
+    assert funder.works_in_year(2022) == 5
+    assert funder.citations_in_year(2021) == 2
+    assert funder.active_years() == [2022]
+
+
+def test_summary_stats_properties() -> None:
+    stats = SummaryStats(h_index=10, i10_index=20)
+    funder = make_funder(summary_stats=stats)
+    assert funder.h_index == 10
+    assert funder.i10_index == 20

--- a/tests/models/test_institution_extra.py
+++ b/tests/models/test_institution_extra.py
@@ -1,0 +1,55 @@
+import pytest
+
+from openalex.models import Institution, CountsByYear, SummaryStats
+
+
+def make_inst(**kwargs: object) -> Institution:
+    data = {
+        "id": "https://openalex.org/I1",
+        "display_name": "Institute",
+        "type": "company",
+        "repositories": [],
+    }
+    data.update(kwargs)
+    return Institution(**data)  # type: ignore[arg-type]
+
+
+def test_type_and_repository_helpers() -> None:
+    inst = make_inst(
+        type="education",
+        repositories=[{"id": "https://openalex.org/S1", "display_name": "Repo"}],
+        geo={"city": "X"},
+    )
+    assert inst.is_education
+    assert not inst.is_company
+    assert inst.type_id == "https://openalex.org/institution-types/education"
+    assert inst.repository_count() == 1
+    assert inst.has_location()
+
+
+def test_parent_and_root_lookup() -> None:
+    inst = make_inst(
+        lineage=["https://openalex.org/I1", "https://openalex.org/I2", "https://openalex.org/Iroot"]
+    )
+    assert inst.parent_institution_id == "https://openalex.org/I2"
+    assert inst.root_institution == "https://openalex.org/Iroot"
+
+
+def test_summary_and_year_helpers() -> None:
+    counts = [CountsByYear(year=2022, works_count=10, cited_by_count=50)]
+    stats = SummaryStats(h_index=5, i10_index=7, two_year_mean_citedness=1.2)
+    inst = make_inst(counts_by_year=counts, summary_stats=stats)
+    assert inst.h_index == 5
+    assert inst.i10_index == 7
+    assert inst.two_year_mean_citedness == 1.2
+    assert inst.works_in_year(2022) == 10
+    assert inst.citations_in_year(2022) == 50
+    assert inst.active_years() == [2022]
+
+
+def test_validators_normalize_fields() -> None:
+    inst = make_inst(image_thumbnail_url="https://x/thumb/logo.png", country_code="us")
+    assert inst.image_thumbnail_url == "https://x/thumbnail/logo.png"
+    assert inst.country_code == "US"
+    with pytest.raises(ValueError):
+        Institution(id="https://openalex.org/I2", display_name="X", country_code="USA")

--- a/tests/models/test_source_extra.py
+++ b/tests/models/test_source_extra.py
@@ -1,0 +1,71 @@
+from openalex.models import (
+    Source,
+    CountsByYear,
+    SummaryStats,
+    SourceType,
+    APCPrice,
+)
+
+
+def make_source(**kwargs: object) -> Source:
+    data = {
+        "id": "https://openalex.org/S1",
+        "display_name": "Test Journal",
+        "type": "journal",
+    }
+    data.update(kwargs)
+    return Source(**data)  # type: ignore[arg-type]
+
+
+def test_issn_validator_handles_none_and_list() -> None:
+    s_none = make_source(issn=None)
+    assert s_none.issn is None
+    s_list = make_source(issn=["1234-5678"])
+    assert s_list.issn == ["1234-5678"]
+
+    # Direct validator call
+    assert Source.ensure_list(None) is None
+    assert Source.ensure_list(["9999-9999"]) == ["9999-9999"]
+
+
+def test_apc_prices_validator_converts_none() -> None:
+    s = make_source(apc_prices=None)
+    assert s.apc_prices == []
+    assert Source._normalize_apc_prices(None) == []
+
+
+def test_type_helpers_and_has_apc() -> None:
+    s = make_source(apc_prices=[APCPrice(price=100, currency="USD")], apc_usd=200)
+    assert s.is_journal
+    assert not s.is_conference
+    assert s.has_apc
+
+
+def test_get_apc_in_currency() -> None:
+    prices = [APCPrice(price=100, currency="USD"), APCPrice(price=90, currency="EUR")]
+    s = make_source(apc_prices=prices)
+    assert s.get_apc_in_currency("eur") == 90
+    assert s.get_apc_in_currency("gbp") is None
+
+
+def test_has_issn_and_all_issns() -> None:
+    s = make_source(issn=["1234-5678", "1234-5678"], issn_l="8765-4321")
+    assert s.has_issn()
+    assert s.all_issns() == ["8765-4321", "1234-5678"]
+
+    many = make_source(
+        issn=["1", "2", "3"],
+        issn_l="0",
+    )
+    assert many.all_issns() == ["0", "1", "2", "3"]
+
+
+def test_year_based_helpers() -> None:
+    counts = [
+        CountsByYear(year=2022, works_count=5, cited_by_count=10),
+        CountsByYear(year=2021, works_count=0, cited_by_count=2),
+    ]
+    s = make_source(counts_by_year=counts)
+    assert s.works_in_year(2022) == 5
+    assert s.citations_in_year(2021) == 2
+    assert s.active_years() == [2022]

--- a/tests/utils/test_pagination_extra.py
+++ b/tests/utils/test_pagination_extra.py
@@ -1,0 +1,73 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from openalex.models import ListResult, Meta
+from openalex.utils.pagination import (
+    _build_params,
+    _pad_results,
+    AsyncPaginator,
+    Paginator,
+)
+
+
+class DummyMeta(Meta):
+    pass
+
+
+def make_list_result(results: list[Any], page: int, per_page: int, next_cursor: str | None = None, count: int | None = None) -> ListResult[Any]:
+    meta = Meta(
+        count=count if count is not None else len(results),
+        db_response_time_ms=0,
+        page=page,
+        per_page=per_page,
+        next_cursor=next_cursor,
+    )
+    return ListResult[Any](meta=meta, results=results)
+
+
+def test_pad_results_and_build_params() -> None:
+    assert _pad_results([], 5) == []
+    assert _pad_results([1, 2], None) == [1, 2]
+    assert _pad_results([1, 2], 4) == [1, 2, 2, 2]
+
+    base = {"a": 1}
+    params = _build_params(base, cursor="c", page=None, per_page=2)
+    assert params == {"a": 1, "cursor": "c", "per_page": 2}
+    params = _build_params(base, cursor=None, page=3, per_page=2)
+    assert params == {"a": 1, "page": 3, "per_page": 2}
+
+
+def test_paginator_first_all_and_count() -> None:
+    pages = {
+        1: make_list_result(["a"], 1, 1, next_cursor="c2", count=2),
+        2: make_list_result(["b"], 2, 1, next_cursor=None, count=2),
+    }
+
+    def fetch(params: dict[str, Any]) -> ListResult[str]:
+        page = int(params.get("page", 1))
+        return pages[page]
+
+    paginator = Paginator(fetch, per_page=1)
+    assert paginator.first() == "a"
+    assert paginator.all() == ["a", "b"]
+    assert paginator.count() == 2
+
+
+@pytest.mark.asyncio
+async def test_async_paginator_methods() -> None:
+    async def fetch(params: dict[str, Any]) -> ListResult[int]:
+        page = int(params.get("page", 1))
+        next_cursor = "c2" if page == 1 else None
+        return make_list_result([page], page, 1, next_cursor=next_cursor, count=2)
+
+    paginator = AsyncPaginator(fetch, per_page=1, concurrency=2)
+    assert await paginator.first() == 1
+    assert await paginator.count() == 1  # count uses SINGLE_PER_PAGE
+
+    all_items = await paginator.all()
+    assert all_items == [1, 2]
+
+    gathered = await paginator.gather(pages=2)
+    assert gathered == [1, 2]


### PR DESCRIPTION
## Summary
- unexclude `openalex/models/funder.py` from coverage
- test additional `Funder` behaviours

## Testing
- `ruff check tests/models/test_funder_extra.py`
- `mypy openalex`
- `ruff check .`
- `pytest` *(fails: Coverage failure: total of 62 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_6855a7b82ff0832ba641afef338578ee